### PR TITLE
Add grafana installation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,6 +16,16 @@ class pe_metrics_dashboard::install {
   service {'influxdb':
     ensure  => running,
     require => Package['influxdb'],
+  }->
+
+  exec {'create influxdb admin user':
+    command => '/usr/bin/influx -execute "CREATE USER admin WITH PASSWORD \'puppet\' WITH ALL PRIVILEGES"',
+    unless => '/usr/bin/influx -username admin -password puppet -execute \'show users\' | grep \'admin true\''
+  }->
+
+  exec {'create influxdb pe_metrics database':
+    command => '/usr/bin/influx -username admin -password puppet -execute "create database pe_metrics"',
+    unless => '/usr/bin/influx -username admin -password puppet -execute \'show databases\' | grep pe_metrics'
   }
 
   yumrepo { 'grafana-repo':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,4 +17,35 @@ class pe_metrics_dashboard::install {
     ensure  => running,
     require => Package['influxdb'],
   }
+
+  yumrepo { 'grafana-repo':
+    ensure        => 'present',
+    baseurl       => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
+    descr         => 'grafana-repository',
+    enabled       => '1',
+    repo_gpgcheck => '1',
+    gpgcheck      => '1',
+    gpgkey        => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
+    sslverify     => '1',
+    sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
+  }->
+
+  class { 'grafana':
+    install_method => 'repo',
+    manage_package_repo => false,
+    version => '4.4.3',
+  }
+
+  # Configure grafana to use InfluxDB
+  grafana_datasource { 'influxdb':
+    grafana_url      => 'http://localhost:3000',
+    type             => 'influxdb',
+    url              => 'http://localhost:8086',
+    access_mode      => 'proxy',
+    is_default       => true,
+    grafana_user     => 'admin',
+    grafana_password => 'admin',
+    require          => Service['grafana-server'],
+  }
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -60,5 +60,16 @@ class pe_metrics_dashboard::install {
     grafana_password => 'admin',
     require          => Service['grafana-server'],
   }
+ 
+  ## install kapacitor
+  package {'kapacitor':
+    ensure => present,
+    source => 'https://dl.influxdata.com/kapacitor/releases/kapacitor-1.3.1.x86_64.rpm',
+    provider => 'rpm',
+  }->
 
+  service {'kapacitor':
+    ensure  => running,
+    enable  => true,
+  }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,9 +50,12 @@ class pe_metrics_dashboard::install {
   grafana_datasource { 'influxdb':
     grafana_url      => 'http://localhost:3000',
     type             => 'influxdb',
+    database         => 'pe_metrics',
     url              => 'http://localhost:8086',
     access_mode      => 'proxy',
     is_default       => true,
+    user             => 'admin',
+    password         => 'puppet',
     grafana_user     => 'admin',
     grafana_password => 'admin',
     require          => Service['grafana-server'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -61,15 +61,24 @@ class pe_metrics_dashboard::install {
     require          => Service['grafana-server'],
   }
  
-  ## install kapacitor
+  ## install / enable kapacitor
   package {'kapacitor':
     ensure => present,
-    source => 'https://dl.influxdata.com/kapacitor/releases/kapacitor-1.3.1.x86_64.rpm',
-    provider => 'rpm',
   }->
 
   service {'kapacitor':
     ensure  => running,
     enable  => true,
   }
+
+  ## install / enable telegraf
+  package {'telegraf':
+    ensure => present,
+  }  
+
+  service {'telegraf':
+    ensure  => running,
+    enable  => true,
+  }
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -87,9 +87,9 @@ class pe_metrics_dashboard::install {
     ensure => present,
   }->
 
-  service 'chronograf':
+  service {'chronograf':
     ensure => running,
-    enabled => true,
+    enable => true,
   }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -74,11 +74,22 @@ class pe_metrics_dashboard::install {
   ## install / enable telegraf
   package {'telegraf':
     ensure => present,
-  }  
+  }->  
 
   service {'telegraf':
     ensure  => running,
     enable  => true,
+  }
+
+  ## install / enable chronograf
+
+  package {'chronograf':
+    ensure => present,
+  }->
+
+  service 'chronograf':
+    ensure => running,
+    enabled => true,
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,8 @@
   "issues_url": "https://github.com/puppetlabs/puppetlabs-pe_metrics_dashboard/issues",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+    {"name":"puppet-grafana", "version_requirement": "3.0.0"}
+    {"name":"golja-influxdb", "version_requirement": "4.0.0"}
   ],
   "data_provider": null
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,8 +8,8 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-pe_metrics_dashboard",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-pe_metrics_dashboard/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
-    {"name":"puppet-grafana", "version_requirement": "3.0.0"}
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppet-grafana", "version_requirement": "3.0.0"},
     {"name":"golja-influxdb", "version_requirement": "4.0.0"}
   ],
   "data_provider": null

--- a/metadata.json
+++ b/metadata.json
@@ -9,8 +9,7 @@
   "issues_url": "https://github.com/puppetlabs/puppetlabs-pe_metrics_dashboard/issues",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
-    {"name":"puppet-grafana", "version_requirement": "3.0.0"},
-    {"name":"golja-influxdb", "version_requirement": "4.0.0"}
+    {"name":"puppet-grafana", "version_requirement": "3.0.0"}
   ],
   "data_provider": null
 }


### PR DESCRIPTION
- Adds installation of grafana to the install.pp manifest.
- Influxdb is added to the grafana instance as a datasource
- The rest of the TICK stack is installed / services managed
- Added dependencies for puppet-grafana to metadata