### PR TITLE
Convert to params.pp format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ pkg
 .bundle
 .yardoc
 Gemfile.lock
+*.swp
+.vagrant
+.rspec

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,90 +1,88 @@
 class pe_metrics_dashboard::install(
-  $add_dashboard_examples =   false,
-  $influxdb_database_name =   'pe_metrics',
-  $grafana_version =          '4.5.2',
-  $grafana_http_port =        '3000',
-) {
+  Boolean $add_dashboard_examples  =  $pe_metrics_dashboard::params::add_dashboard_examples,
+  String $influx_db_service_name   =  $pe_metrics_dashboard::params::influx_db_service_name,
+  String $influxdb_database_name   =  $pe_metrics_dashboard::params::influxdb_database_name,
+  String $grafana_version          =  $pe_metrics_dashboard::params::grafana_version,
+  Integer $grafana_http_port       =  $pe_metrics_dashboard::params::grafana_http_port,
+  String $influx_db_password       =  $pe_metrics_dashboard::params::influx_db_password,
+  String $grafana_password         =  $pe_metrics_dashboard::params::grafana_password
+) inherits pe_metrics_dashboard::params {
 
-  case $::osfamily {
+  include pe_metrics_dashboard::repos
 
-    'RedHat': {  
-       $influx_db_service_name = 'influxdb'
-    }
-    'Debian': {
-      $influx_db_service_name = 'influxd'
-    }
-    default: {
-      fail("$::osfamily installation not supported")
-    }
+  package { 'influxdb':
+    ensure  => present,
+    require => Class['pe_metrics_dashboard::repos'],
   }
 
-  class {'pe_metrics_dashboard::repos':}->
-
-  package {'influxdb':
-    ensure  => present,
-  }->
-
-  service {"${influx_db_service_name}":
+  service { $influx_db_service_name:
     ensure  => running,
     require => Package['influxdb'],
-  }->
+  }
 
   class { 'grafana':
-    install_method => 'repo',
+    install_method      => 'repo',
     manage_package_repo => false,
-    version => $grafana_version,
-    cfg => {
+    version             => $grafana_version,
+    cfg                 => {
       server   => {
         http_port      => $grafana_http_port,
       },
     },
-  }->
+    require             => Service[$influx_db_service_name],
+  }
 
   ## install / enable kapacitor
-  package {'kapacitor':
-    ensure => present,
+  ->package { 'kapacitor':
+    ensure  => present,
     require => Class['pe_metrics_dashboard::repos'],
-  }->
+  }
 
-  service {'kapacitor':
-    ensure  => running,
-    enable  => true,
-  }->
-
-  ## install / enable telegraf
-  package {'telegraf':
-    ensure => present,
-    require => Class['pe_metrics_dashboard::repos'],
-  }->
-
-  service {'telegraf':
-    ensure  => running,
-    enable  => true,
-  }->
-
-  ## install / enable chronograf
-  package {'chronograf':
-    ensure => present,
-    require => Class['pe_metrics_dashboard::repos'],
-  }->
-
-  service {'chronograf':
+  ->service { 'kapacitor':
     ensure => running,
     enable => true,
-  }->
+  }
+  -> package { 'telegraf':
+    ensure  => present,
+    require => Class['pe_metrics_dashboard::repos'],
+  }
 
-  exec {'create influxdb admin user':
-    command => '/usr/bin/influx -execute "CREATE USER admin WITH PASSWORD \'puppet\' WITH ALL PRIVILEGES"',
-    unless => '/usr/bin/influx -username admin -password puppet -execute \'show users\' | grep \'admin true\''
-  }->
+  ->service { 'telegraf':
+    ensure => running,
+    enable => true,
+  }
 
-  exec {'create influxdb pe_metrics database':
-    command => "/usr/bin/influx -username admin -password puppet -execute \"create database ${influxdb_database_name}\"",
-    unless => "/usr/bin/influx -username admin -password puppet -execute \'show databases\' | grep ${$influxdb_database_name}"
-  }->
+  ## install / enable chronograf
+  ->package { 'chronograf':
+    ensure  => present,
+    require => Class['pe_metrics_dashboard::repos'],
+  }
+
+  ->service { 'chronograf':
+    ensure => running,
+    enable => true,
+  }
+
+  # Fix a timing issue where influxdb does not start fully before creating users
+  ->exec { 'wait for influxdb':
+    command => '/bin/sleep 5',
+    unless  => '/usr/bin/influx -execute "SHOW DATABASES"',
+    require => Service['influxdb'],
+  }
+
+  ->exec { 'create influxdb admin user':
+    command => "/usr/bin/influx -execute \"CREATE USER admin WITH PASSWORD '${influx_db_password}' WITH ALL PRIVILEGES\"",
+    unless  => "/usr/bin/influx -username admin -password ${influx_db_password} -execute \'show users\' | grep \'admin true\'",
+    require => Exec['wait for influxdb'],
+  }
+
+  ->exec { 'create influxdb pe_metrics database':
+    command => "/usr/bin/influx -username admin -password ${influx_db_password} -execute \"create database ${influxdb_database_name}\"",
+    unless  => "/usr/bin/influx -username admin -password ${influx_db_password} -execute \'show databases\' | grep ${$influxdb_database_name}",
+  }
 
   # Configure grafana to use InfluxDB
-  grafana_datasource { "influxdb":
+  ->grafana_datasource { 'influxdb':
     grafana_url      => "http://localhost:${grafana_http_port}",
     type             => 'influxdb',
     database         => $influxdb_database_name,
@@ -92,32 +90,35 @@ class pe_metrics_dashboard::install(
     access_mode      => 'proxy',
     is_default       => true,
     user             => 'admin',
-    password         => 'puppet',
+    password         => $influx_db_password,
     grafana_user     => 'admin',
     grafana_password => 'admin',
-    require          => Service['grafana-server'],
+    require          => [Service['grafana-server'], Exec['create influxdb pe_metrics database']],
   }
 
   if $add_dashboard_examples {
     grafana_dashboard { 'PuppetDB Performance':
-      grafana_url       => "http://localhost:${grafana_http_port}",
-      grafana_user      => 'admin',
-      grafana_password  => 'admin',
-      content           => file('pe_metrics_dashboard/PuppetDB_Performance.json'),
+      grafana_url      => "http://localhost:${grafana_http_port}",
+      grafana_user     => 'admin',
+      grafana_password => $grafana_password,
+      content          => file('pe_metrics_dashboard/PuppetDB_Performance.json'),
+      require          => Grafana_datasource['influxdb'],
     }
 
     grafana_dashboard { 'PuppetDB Workload':
-      grafana_url       => "http://localhost:${grafana_http_port}",
-      grafana_user      => 'admin',
-      grafana_password  => 'admin',
-      content           => file('pe_metrics_dashboard/PuppetDB_Workload.json'),
+      grafana_url      => "http://localhost:${grafana_http_port}",
+      grafana_user     => 'admin',
+      grafana_password => $grafana_password,
+      content          => file('pe_metrics_dashboard/PuppetDB_Workload.json'),
+      require          => Grafana_datasource['influxdb'],
     }
- 
+
     grafana_dashboard { 'Puppetserver Performance':
-      grafana_url       => "http://localhost:${grafana_http_port}",
-      grafana_user      => 'admin',
-      grafana_password  => 'admin',
-      content           => file('pe_metrics_dashboard/Puppetserver_Performance.json'),
+      grafana_url      => "http://localhost:${grafana_http_port}",
+      grafana_user     => 'admin',
+      grafana_password => $grafana_password,
+      content          => file('pe_metrics_dashboard/Puppetserver_Performance.json'),
+      require          => Grafana_datasource['influxdb'],
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,31 @@
+# pe_metrics_dashboard::params
+#
+# A description of what this class does
+#
+# @summary Default parameters for the installation
+#
+# @example
+class pe_metrics_dashboard::params {
+
+  # Default Installation parameters
+  $add_dashboard_examples =  false
+  $influxdb_database_name =  'pe_metrics'
+  $grafana_version        =  '4.5.2'
+  $grafana_http_port      =  3000
+  $influx_db_password     =  'puppet'
+  $grafana_password       =  'admin'
+
+  case $::osfamily {
+
+    'RedHat': {
+      $influx_db_service_name = 'influxdb'
+    }
+    'Debian': {
+      $influx_db_service_name = 'influxd'
+    }
+    default: {
+      fail("${::osfamily} installation not supported")
+    }
+  }
+
+}

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -4,27 +4,27 @@ class pe_metrics_dashboard::repos{
 
     'RedHat': {
 
-       yumrepo {'influxdb':
-          ensure   => present,
-          enabled  => 1,
-          gpgcheck => 1,
-          baseurl  => 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable',
-          gpgkey   => 'https://repos.influxdata.com/influxdb.key',
-          before => Package['influxdb'],
-       }
+      yumrepo {'influxdb':
+        ensure   => present,
+        enabled  => 1,
+        gpgcheck => 1,
+        baseurl  => 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable',
+        gpgkey   => 'https://repos.influxdata.com/influxdb.key',
+        before   => Package['influxdb'],
+      }
 
-       yumrepo { 'grafana-repo':
-         ensure        => 'present',
-         baseurl       => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
-         descr         => 'grafana-repository',
-         enabled       => '1',
-         repo_gpgcheck => '1',
-         gpgcheck      => '1',
-         gpgkey        => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
-         sslverify     => '1',
-         sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
-         before        => Class['grafana'],
-       }
+      yumrepo { 'grafana-repo':
+        ensure        => 'present',
+        baseurl       => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
+        descr         => 'grafana-repository',
+        enabled       => '1',
+        repo_gpgcheck => '1',
+        gpgcheck      => '1',
+        gpgkey        => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
+        sslverify     => '1',
+        sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
+        before        => Class['grafana'],
+      }
     }
 
     'Debian': {
@@ -39,7 +39,7 @@ class pe_metrics_dashboard::repos{
           'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',
           'source' => 'https://repos.influxdata.com/influxdb.key',
         },
-        before => Package['influxdb'],
+        before   => Package['influxdb'],
       }
 
       apt::source { 'grafana':
@@ -50,12 +50,12 @@ class pe_metrics_dashboard::repos{
           'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',
           'source' => 'https://packagecloud.io/gpg.key',
         },
-        before => Package['grafana'],
+        before   => Package['grafana'],
       }
     }
 
     default: {
-      fail("$::osfamily installation not supported")
+      fail("${::osfamily} installation not supported")
     }
   }
 


### PR DESCRIPTION
Prior to this PR the parameters were in the install.pp class. This
commit changes the parameters into the params.pp format.

This PR updates to the code to comply with `puppet-lint`.