### PR TITLE
Add parameters for the TICK stack

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -67,7 +67,7 @@ class pe_metrics_dashboard::install(
   ->exec { 'wait for influxdb':
     command => '/bin/sleep 5',
     unless  => '/usr/bin/influx -execute "SHOW DATABASES"',
-    require => Service['influxdb'],
+    require => Service[$influx_db_service_name],
   }
 
   ->exec { 'create influxdb admin user':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,11 @@ class pe_metrics_dashboard::params {
   $grafana_http_port      =  3000
   $influx_db_password     =  'puppet'
   $grafana_password       =  'admin'
+  # Influxdb TICK stack
+  $enable_telegraf        = true
+  $enable_kapacitor       = false
+  $enable_chronograf      = false
+
 
   case $::osfamily {
 


### PR DESCRIPTION
This PR fixes that and introduces the following changes. 

* Add parameters for the TICK stack
* Change chaining arrows to `require`
* Fix the hardcoded influxdb name from #6 which broke Ubuntu installs