### PR TITLE
add telegraf configuration

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,9 @@ class pe_metrics_dashboard::install(
   Boolean $enable_kapacitor        =  $pe_metrics_dashboard::params::enable_kapacitor,
   Boolean $enable_chronograf       =  $pe_metrics_dashboard::params::enable_chronograf,
   Boolean $enable_telegraf         =  $pe_metrics_dashboard::params::enable_telegraf,
+  Boolean $configure_telegraf      =  $pe_metrics_dashboard::params::configure_telegraf,
+  Array[String] $master_list       =  $pe_metrics_dashboard::params::master_list,
+  Array[String] $puppetdb_list     =  $pe_metrics_dashboard::params::puppetdb_list  
 ) inherits pe_metrics_dashboard::params {
 
   include pe_metrics_dashboard::repos
@@ -53,6 +56,17 @@ class pe_metrics_dashboard::install(
       ensure  => present,
       require => Class['pe_metrics_dashboard::repos'],
     }
+
+    if $configure_telegraf {
+      
+      file {'/etc/telegraf/telegraf.conf':
+        ensure  => file,
+        owner   => 0,
+        group   => 0,
+        content => epp('pe_metrics_dashboard/telegraf.conf.epp'),
+        notify  => Service['telegraf'],
+      }
+    }    
 
     service { 'telegraf':
       ensure  => running,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,9 +15,13 @@ class pe_metrics_dashboard::params {
   $influx_db_password     =  'puppet'
   $grafana_password       =  'admin'
   # Influxdb TICK stack
-  $enable_telegraf        = true
-  $enable_kapacitor       = false
-  $enable_chronograf      = false
+  $enable_telegraf        =  true
+  $enable_kapacitor       =  false
+  $enable_chronograf      =  false
+  # telegraf config
+  $configure_telegraf     =  false
+  $master_list            =  []
+  $puppetdb_list          =  []
 
 
   case $::osfamily {

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -1,0 +1,48 @@
+[global_tags]
+[agent]
+  interval = "10s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "0s"
+  precision = ""
+  debug = false
+  quiet = false
+  logfile = ""
+  hostname = ""
+  omit_hostname = false
+[[outputs.influxdb]]
+  urls = ["http://localhost:8086"] # required
+  database = "telegraf" # required
+  retention_policy = ""
+  write_consistency = "any"
+  timeout = "5s"
+
+[[inputs.httpjson]]
+  name = "puppet_stats"
+  servers = [
+    <%# -%>
+    <% unless $pe_metrics_dashboard::install::master_list.empty {-%>
+    <% $pe_metrics_dashboard::install::master_list.each |$master_list| {-%>
+    "https://<%= $master_list %>:8140/status/v1/services?level=debug",
+    <% } -%>
+    <% } -%>
+    <%# -%>
+  ]
+  method = "GET"
+  insecure_skip_verify = true
+[[inputs.httpjson]]
+  name = "puppetdb_stats"
+  servers = [
+    <%# -%>
+    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
+    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
+    "https://<%= $puppetdb_list %>:8081/status/v1/services?level=debug",
+    <% } -%>
+    <% } -%>
+    <%# -%>
+  ]
+  method = "GET"
+  insecure_skip_verify = true


### PR DESCRIPTION
now you can do:

```
class {'pe_metrics_dashboard::install':
   influxdb_database_name => 'telegraf',
   master_list                        => ["master.com"],
   puppetdb_list                   => ["pdb1.com","pdb2.com"],
   configure_telegraf            => true,
   enable_telegraf                => true,
}
```

telegraf will start polling the status endpoints of any masters / puppetdb nodes in the arrays and getting live metrics.