### PR TITLE
Multiple datasoures

### DIFF
--- a/files/PuppetDB_Performance.json
+++ b/files/PuppetDB_Performance.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_INFLUXDB",
-      "label": "influxdb",
+      "name": "DS_INFLUXDB_PE_METRICS",
+      "label": "influxdb_pe_metrics",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.4.3"
+      "version": "4.5.2"
     },
     {
       "type": "panel",
@@ -55,7 +55,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -160,7 +160,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -277,7 +277,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -394,7 +394,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 4,
           "legend": {
@@ -499,7 +499,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 5,
           "legend": {
@@ -604,7 +604,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -720,8 +720,8 @@
     "list": []
   },
   "time": {
-    "from": "2017-09-19T23:37:12.613Z",
-    "to": "2017-09-20T22:53:20.404Z"
+    "from": "now-2d",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -750,5 +750,5 @@
   },
   "timezone": "",
   "title": "PuppetDB Performance",
-  "version": 2
+  "version": 3
 }

--- a/files/PuppetDB_Workload.json
+++ b/files/PuppetDB_Workload.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_INFLUXDB",
-      "label": "influxdb",
+      "name": "DS_INFLUXDB_PE_METRICS",
+      "label": "influxdb_pe_metrics",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.4.3"
+      "version": "4.5.2"
     },
     {
       "type": "panel",
@@ -55,7 +55,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -178,7 +178,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -289,7 +289,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -400,7 +400,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 4,
           "legend": {
@@ -523,7 +523,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 5,
           "legend": {
@@ -628,7 +628,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -733,7 +733,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 7,
           "legend": {
@@ -850,7 +850,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 8,
           "legend": {
@@ -955,7 +955,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 9,
           "legend": {
@@ -1071,8 +1071,8 @@
     "list": []
   },
   "time": {
-    "from": "2017-09-19T22:35:35.312Z",
-    "to": "2017-09-20T23:49:45.062Z"
+    "from": "now-2d",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -1101,5 +1101,5 @@
   },
   "timezone": "",
   "title": "PuppetDB Workload",
-  "version": 2
+  "version": 3
 }

--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_INFLUXDB",
-      "label": "influxdb",
+      "name": "DS_INFLUXDB_PE_METRICS",
+      "label": "influxdb_pe_metrics",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.4.3"
+      "version": "4.5.2"
     },
     {
       "type": "panel",
@@ -55,7 +55,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -301,7 +301,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -508,7 +508,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -614,7 +614,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 4,
           "legend": {
@@ -732,7 +732,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 5,
           "legend": {
@@ -838,7 +838,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb",
+          "datasource": "${DS_INFLUXDB_PE_METRICS}",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -955,8 +955,8 @@
     "list": []
   },
   "time": {
-    "from": "2017-08-25T14:04:15.573Z",
-    "to": "2017-08-25T17:12:36.177Z"
+    "from": "now-2d",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -985,5 +985,5 @@
   },
   "timezone": "",
   "title": "Puppetserver Performance",
-  "version": 7
+  "version": 3
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -122,7 +122,7 @@ class pe_metrics_dashboard::install(
       password         => $influx_db_password,
       grafana_user     => 'admin',
       grafana_password => 'admin',
-      require          => [Service['grafana-server'], Exec['create influxdb pe_metrics database']],
+      require          => [Service['grafana-server'], Exec["create influxdb pe_metrics database ${db_name}"]],
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -122,6 +122,7 @@ class pe_metrics_dashboard::install(
       grafana_password => 'admin',
       require          => [Service['grafana-server'], Exec['create influxdb pe_metrics database']],
     }
+  }
 
   if $add_dashboard_examples {
     grafana_dashboard { 'PuppetDB Performance':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -104,7 +104,7 @@ class pe_metrics_dashboard::install(
   $influxdb_database_name.each |$db_name| {
     exec { "create influxdb pe_metrics database ${db_name}":
       command => "/usr/bin/influx -username admin -password ${influx_db_password} -execute \"create database ${db_name}\"",
-      unless  => "/usr/bin/influx -username admin -password ${influx_db_password} -execute \'show databases\' | grep ${$influxdb_database_name}",
+      unless  => "/usr/bin/influx -username admin -password ${influx_db_password} -execute \'show databases\' | grep ${db_name}",
       require => Exec['create influxdb admin user'],
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,17 +1,17 @@
 class pe_metrics_dashboard::install(
-  Boolean $add_dashboard_examples  =  $pe_metrics_dashboard::params::add_dashboard_examples,
-  String $influx_db_service_name   =  $pe_metrics_dashboard::params::influx_db_service_name,
-  String $influxdb_database_name   =  $pe_metrics_dashboard::params::influxdb_database_name,
-  String $grafana_version          =  $pe_metrics_dashboard::params::grafana_version,
-  Integer $grafana_http_port       =  $pe_metrics_dashboard::params::grafana_http_port,
-  String $influx_db_password       =  $pe_metrics_dashboard::params::influx_db_password,
-  String $grafana_password         =  $pe_metrics_dashboard::params::grafana_password,
-  Boolean $enable_kapacitor        =  $pe_metrics_dashboard::params::enable_kapacitor,
-  Boolean $enable_chronograf       =  $pe_metrics_dashboard::params::enable_chronograf,
-  Boolean $enable_telegraf         =  $pe_metrics_dashboard::params::enable_telegraf,
-  Boolean $configure_telegraf      =  $pe_metrics_dashboard::params::configure_telegraf,
-  Array[String] $master_list       =  $pe_metrics_dashboard::params::master_list,
-  Array[String] $puppetdb_list     =  $pe_metrics_dashboard::params::puppetdb_list  
+  Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::params::add_dashboard_examples,
+  String $influx_db_service_name          =  $pe_metrics_dashboard::params::influx_db_service_name,
+  Array[String] $influxdb_database_name   =  $pe_metrics_dashboard::params::influxdb_database_name,
+  String $grafana_version                 =  $pe_metrics_dashboard::params::grafana_version,
+  Integer $grafana_http_port              =  $pe_metrics_dashboard::params::grafana_http_port,
+  String $influx_db_password              =  $pe_metrics_dashboard::params::influx_db_password,
+  String $grafana_password                =  $pe_metrics_dashboard::params::grafana_password,
+  Boolean $enable_kapacitor               =  $pe_metrics_dashboard::params::enable_kapacitor,
+  Boolean $enable_chronograf              =  $pe_metrics_dashboard::params::enable_chronograf,
+  Boolean $enable_telegraf                =  $pe_metrics_dashboard::params::enable_telegraf,
+  Boolean $configure_telegraf             =  $pe_metrics_dashboard::params::configure_telegraf,
+  Array[String] $master_list              =  $pe_metrics_dashboard::params::master_list,
+  Array[String] $puppetdb_list            =  $pe_metrics_dashboard::params::puppetdb_list  
 ) inherits pe_metrics_dashboard::params {
 
   include pe_metrics_dashboard::repos
@@ -107,20 +107,21 @@ class pe_metrics_dashboard::install(
     require => Exec['create influxdb admin user'],
   }
 
-  # Configure grafana to use InfluxDB
-  grafana_datasource { 'influxdb':
-    grafana_url      => "http://localhost:${grafana_http_port}",
-    type             => 'influxdb',
-    database         => $influxdb_database_name,
-    url              => 'http://localhost:8086',
-    access_mode      => 'proxy',
-    is_default       => true,
-    user             => 'admin',
-    password         => $influx_db_password,
-    grafana_user     => 'admin',
-    grafana_password => 'admin',
-    require          => [Service['grafana-server'], Exec['create influxdb pe_metrics database']],
-  }
+  # Configure grafana to use InfluxDB with any number of database names
+  $influxdb_database_name.each |$db_name| {
+    grafana_datasource { 'influxdb':
+      grafana_url      => "http://localhost:${grafana_http_port}",
+      type             => 'influxdb',
+      database         => $db_name,
+      url              => 'http://localhost:8086',
+      access_mode      => 'proxy',
+      is_default       => false,
+      user             => 'admin',
+      password         => $influx_db_password,
+      grafana_user     => 'admin',
+      grafana_password => 'admin',
+      require          => [Service['grafana-server'], Exec['create influxdb pe_metrics database']],
+    }
 
   if $add_dashboard_examples {
     grafana_dashboard { 'PuppetDB Performance':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class pe_metrics_dashboard::params {
 
   # Default Installation parameters
   $add_dashboard_examples =  false
-  $influxdb_database_name =  'pe_metrics'
+  $influxdb_database_name =  ["pe_metrics"]
   $grafana_version        =  '4.5.2'
   $grafana_http_port      =  3000
   $influx_db_password     =  'puppet'


### PR DESCRIPTION
This change allows you to set $influxdb_database_name to an array so that multiple influxdb databases are configured as a datasource.  

This will allow the user to use more than one collection method if desired.