### PR TITLE
add graphite listener to influxdb config

### DIFF
--- a/files/influxdb.conf
+++ b/files/influxdb.conf
@@ -1,0 +1,27 @@
+[meta]
+  dir = "/var/lib/influxdb/meta"
+[data]
+  dir = "/var/lib/influxdb/data"
+  wal-dir = "/var/lib/influxdb/wal"
+[coordinator]
+[retention]
+[shard-precreation]
+[monitor]
+[http]
+[subscriber]
+[[graphite]]
+  enabled = true
+  database = "graphite"
+  retention-policy = ""
+  bind-address = ":2003"
+  protocol = "tcp"
+  consistency-level = "one"
+  batch-size = 5000
+  batch-pending = 10
+  batch-timeout = "1s"
+  udp-read-buffer = 0
+  separator = "."
+[[collectd]]
+[[opentsdb]]
+[[udp]]
+[continuous_queries]

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,6 +10,7 @@ class pe_metrics_dashboard::install(
   Boolean $enable_chronograf              =  $pe_metrics_dashboard::params::enable_chronograf,
   Boolean $enable_telegraf                =  $pe_metrics_dashboard::params::enable_telegraf,
   Boolean $configure_telegraf             =  $pe_metrics_dashboard::params::configure_telegraf,
+  Boolean $consume_graphite               =  $pe_metrics_dashboard::params::consume_graphite,
   Array[String] $master_list              =  $pe_metrics_dashboard::params::master_list,
   Array[String] $puppetdb_list            =  $pe_metrics_dashboard::params::puppetdb_list  
 ) inherits pe_metrics_dashboard::params {
@@ -21,6 +22,17 @@ class pe_metrics_dashboard::install(
     require => Class['pe_metrics_dashboard::repos'],
   }
 
+  if $consume_graphite {
+
+    file {'/etc/influxdb/influxdb.conf':
+      ensure  => file,
+      owner   => 0,
+      group   => 0,
+      content => file('pe_metrics_dashboard/influxdb.conf'),
+      notify  => Service["${influx_db_service_name}"],
+    }
+  }
+ 
   service { $influx_db_service_name:
     ensure  => running,
     require => Package['influxdb'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class pe_metrics_dashboard::params {
   $grafana_http_port      =  3000
   $influx_db_password     =  'puppet'
   $grafana_password       =  'admin'
+  $consume_graphite       =  false
   # Influxdb TICK stack
   $enable_telegraf        =  true
   $enable_kapacitor       =  false


### PR DESCRIPTION
influxdb can consume graphite metrics, so with a simple change to the config we can listen for those metrics sent when puppetserver is configured as described here:

https://puppet.com/docs/pe/2017.3/puppet_server_metrics/getting_started_with_graphite.html#enabling-puppet-server-graphite-support