### PR TITLE
expand telegraf puppetdb metrics and dash

### DIFF
--- a/files/Telegraf_PuppetDB_Performance.json
+++ b/files/Telegraf_PuppetDB_Performance.json
@@ -42,7 +42,7 @@
   "rows": [
     {
       "collapse": false,
-      "height": "250px",
+      "height": 250,
       "panels": [
         {
           "aliasColors": {},
@@ -51,13 +51,13 @@
           "dashes": false,
           "datasource": "influxdb_telegraf",
           "fill": 1,
-          "id": 1,
+          "id": 5,
           "legend": {
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -91,7 +91,346 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppetdb_catalog_stats",
+              "measurement": "httpjson_puppetdb_command_global_processed",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "FiveMinuteRate"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Commands Per Second",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_command_global_processing_time",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "FiveMinuteRate"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Command Processing time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_command_queue",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "puppetdb-status_status_queue_depth"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Queue Depth",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_command_catalog_processing",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -162,7 +501,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -176,7 +515,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 6,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -196,7 +535,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppetdb_facts_stats",
+              "measurement": "httpjson_puppetdb_command_fact_processing",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -222,6 +561,111 @@
           "timeFrom": null,
           "timeShift": null,
           "title": "Replace Facts Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_command_report_storage",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "95thPercentile"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Store Report Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -300,5 +744,5 @@
   },
   "timezone": "",
   "title": "Telegraf PuppetDB Performance",
-  "version": 3
+  "version": 9
 }

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -10,7 +10,7 @@
   precision = ""
   debug = false
   quiet = false
-  logfile = ""
+  logfile = "/var/log/telegraf/telegraf.log"
   hostname = ""
   omit_hostname = false
 [[outputs.influxdb]]
@@ -34,7 +34,7 @@
   method = "GET"
   insecure_skip_verify = true
 [[inputs.httpjson]]
-  name = "puppetdb_stats"
+  name = "puppetdb_command_queue"
   servers = [
     <%# -%>
     <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
@@ -44,5 +44,71 @@
     <% } -%>
     <%# -%>
   ]
+  method = "GET"
+  insecure_skip_verify = true
+
+[[inputs.httpjson]]
+  name = "puppetdb_command_global_processed"
+  servers = [
+    <%# -%>
+    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
+    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
+    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq:name=global.processed",
+    <% } -%>
+    <% } -%>
+    <%# -%>
+            ]
+  method = "GET"
+  insecure_skip_verify = true
+[[inputs.httpjson]]
+  name = "puppetdb_command_global_processing_time"
+  servers = [
+    <%# -%>
+    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
+    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
+    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dreplace+facts.5.processing-time",
+    <% } -%>
+    <% } -%>
+    <%# -%>
+            ]
+  method = "GET"
+  insecure_skip_verify = true
+[[inputs.httpjson]]
+  name = "puppetdb_command_catalog_processing"
+  servers = [
+    <%# -%>
+    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
+    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
+    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dreplace+catalog.9.processing-time",
+    <% } -%>
+    <% } -%>
+    <%# -%>
+            ]
+  method = "GET"
+  insecure_skip_verify = true
+[[inputs.httpjson]]
+  name = "puppetdb_command_fact_processing"
+  servers = [
+    <%# -%>
+    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
+    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
+    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dreplace+facts.5.processing-time",
+    <% } -%>
+    <% } -%>
+    <%# -%>
+            ]
+  method = "GET"
+  insecure_skip_verify = true
+[[inputs.httpjson]]
+  name = "puppetdb_command_report_storage"
+  servers = [
+    <%# -%>
+    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
+    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
+    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dstore+report.8.processing-time",
+    <% } -%>
+    <% } -%>
+    <%# -%>
+            ]
   method = "GET"
   insecure_skip_verify = true


### PR DESCRIPTION
This expands the "Telegraf PuppetDB Performance" dashboard and the telegraf config that puts metrics there.

Also specifying a logfile to telegraf config.  It didn't always log somewhere in various OSes