### PR TITLE
Add mbean metrics to PuppetDB in telegraf 

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,7 +53,7 @@ with:
 This will run the tests on an Ubuntu 12.04 virtual machine. You can also
 run the integration tests against Centos 6.5 with.
 
-    RS_SET=centos-64-x64 bundle exec rake acceptances
+    RS_SET=centos-64-x64 bundle exec rake acceptance
 
 If you don't want to have to recreate the virtual machine every time you
 can use `BEAKER_DESTROY=no` and `BEAKER_PROVISION=no`. On the first run you will
@@ -63,6 +63,6 @@ for the created virtual machines will be in `.vagrant/beaker_vagrant_fies`.
 Docker is used for acceptance testing in travis. This can be run locally by setting
 environment variables as a part of the test.
 
-   PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7 bundle exec rake acceptance
+    PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7 bundle exec rake acceptance
 
 This document is sourced from https://github.com/voxpupuli/puppet-grafana/blob/master/CONTRIBUTING.md

--- a/files/Graphite_Puppetserver_Performance.json
+++ b/files/Graphite_Puppetserver_Performance.json
@@ -37,7 +37,17 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "graphite"
+      ],
+      "type": "dashboards"
+    }
+  ],
   "refresh": "5s",
   "rows": [
     {
@@ -2427,7 +2437,9 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "graphite"
+  ],
   "templating": {
     "list": []
   },
@@ -2467,6 +2479,6 @@
     "type": "timepicker"
   },
   "timezone": "browser",
-  "title": "Graphite - PE Puppet Server",
-  "version": 6
+  "title": "Graphite Puppetserver Performance",
+  "version": 4
 }

--- a/files/PuppetDB_Performance.json
+++ b/files/PuppetDB_Performance.json
@@ -37,7 +37,17 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "archive"
+      ],
+      "type": "dashboards"
+    }
+  ],
   "refresh": false,
   "rows": [
     {
@@ -709,7 +719,9 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "archive"
+  ],
   "templating": {
     "list": []
   },
@@ -743,6 +755,6 @@
     ]
   },
   "timezone": "",
-  "title": "PuppetDB Performance",
-  "version": 3
+  "title": "Archive PuppetDB Performance",
+  "version": 5
 }

--- a/files/PuppetDB_Workload.json
+++ b/files/PuppetDB_Workload.json
@@ -37,7 +37,18 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "archive"
+      ],
+      "targetBlank": true,
+      "type": "dashboards"
+    }
+  ],
   "refresh": false,
   "rows": [
     {
@@ -1060,7 +1071,9 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "archive"
+  ],
   "templating": {
     "list": []
   },
@@ -1094,6 +1107,6 @@
     ]
   },
   "timezone": "",
-  "title": "PuppetDB Workload",
-  "version": 3
+  "title": "Archive PuppetDB Workload",
+  "version": 4
 }

--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -37,7 +37,17 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "archive"
+      ],
+      "type": "dashboards"
+    }
+  ],
   "refresh": false,
   "rows": [
     {
@@ -944,7 +954,9 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "archive"
+  ],
   "templating": {
     "list": []
   },
@@ -978,6 +990,6 @@
     ]
   },
   "timezone": "",
-  "title": "Puppetserver Performance",
+  "title": "Archive Puppetserver Performance",
   "version": 4
 }

--- a/files/Telegraf_PuppetDB_Performance.json
+++ b/files/Telegraf_PuppetDB_Performance.json
@@ -37,7 +37,19 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "telegraf"
+      ],
+      "title": "",
+      "type": "dashboards"
+    }
+  ],
   "refresh": "5s",
   "rows": [
     {
@@ -76,6 +88,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_host",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -86,12 +99,18 @@
                 },
                 {
                   "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppetdb_command_global_processed",
+              "measurement": "httpjson_puppetdb_global_processed",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -110,7 +129,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -181,6 +206,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_host",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -191,12 +217,18 @@
                 },
                 {
                   "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppetdb_command_global_processing_time",
+              "measurement": "httpjson_puppetdb_global_processing-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -215,7 +247,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -298,6 +336,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_host",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -305,6 +344,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -332,7 +377,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -415,6 +466,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_host",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -425,12 +477,18 @@
                 },
                 {
                   "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppetdb_command_catalog_processing",
+              "measurement": "httpjson_puppetdb_storage_replace-catalog-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -449,7 +507,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -520,6 +584,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_host",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -530,12 +595,18 @@
                 },
                 {
                   "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppetdb_command_fact_processing",
+              "measurement": "httpjson_puppetdb_storage_replace-facts-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -554,7 +625,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -625,6 +702,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_host",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -635,12 +713,18 @@
                 },
                 {
                   "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppetdb_command_report_storage",
+              "measurement": "httpjson_puppetdb_storage_store-report-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -659,7 +743,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -709,9 +799,33 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "telegraf",
+    "puppetdb"
+  ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "influxdb_telegraf",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Host",
+        "multi": false,
+        "name": "host",
+        "options": [],
+        "query": "SHOW TAG VALUES WITH KEY = \"host\"",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-1h",

--- a/files/Telegraf_PuppetDB_Workload.json
+++ b/files/Telegraf_PuppetDB_Workload.json
@@ -48,11 +48,10 @@
       "type": "dashboards"
     }
   ],
-  "refresh": "5s",
   "rows": [
     {
       "collapse": false,
-      "height": 367,
+      "height": 257,
       "panels": [
         {
           "aliasColors": {},
@@ -74,28 +73,19 @@
           "lines": true,
           "linewidth": 1,
           "links": [],
-          "nullPointMode": "connected",
+          "nullPointMode": "null",
           "percentage": false,
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "ave-wait-time",
-              "yaxis": 2
-            },
-            {
-              "alias": "ave-borrow-time",
-              "yaxis": 2
-            }
-          ],
+          "seriesOverrides": [],
           "spaceLength": 10,
           "span": 12,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host-ave. free jrubies",
+              "alias": "$tag_host",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -117,174 +107,16 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppet_stats",
+              "measurement": "httpjson_puppetdb_global_message-persistence-time",
               "orderByTime": "ASC",
               "policy": "default",
-              "query": "SELECT distinct(\"pe-jruby-metrics_status_experimental_metrics_average-free-jrubies\") FROM \"httpjson_puppet_stats\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
-              "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
               "select": [
                 [
                   {
                     "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-free-jrubies"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "distinct"
-                  }
-                ]
-              ],
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/^$host$/"
-                }
-              ]
-            },
-            {
-              "alias": "$tag_host-ave. requested jrubies",
-              "dsType": "influxdb",
-              "groupBy": [
-                {
-                  "params": [
-                    "$__interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "host"
-                  ],
-                  "type": "tag"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "httpjson_puppet_stats",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "SELECT distinct(\"pe-jruby-metrics_status_experimental_metrics_average-requested-jrubies\") FROM \"httpjson_puppet_stats\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
-              "rawQuery": false,
-              "refId": "B",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-requested-jrubies"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "distinct"
-                  }
-                ]
-              ],
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/^$host$/"
-                }
-              ]
-            },
-            {
-              "alias": "$tag_host-ave-borrow-time",
-              "dsType": "influxdb",
-              "groupBy": [
-                {
-                  "params": [
-                    "$__interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "host"
-                  ],
-                  "type": "tag"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "httpjson_puppet_stats",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "SELECT distinct(\"pe-jruby-metrics_status_experimental_metrics_average-borrow-time\") FROM \"httpjson_puppet_stats\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
-              "rawQuery": false,
-              "refId": "C",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-borrow-time"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "distinct"
-                  }
-                ]
-              ],
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/^$host$/"
-                }
-              ]
-            },
-            {
-              "alias": "$tag_host-ave-wait-time",
-              "dsType": "influxdb",
-              "groupBy": [
-                {
-                  "params": [
-                    "$__interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "host"
-                  ],
-                  "type": "tag"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "httpjson_puppet_stats",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "SELECT distinct(\"pe-jruby-metrics_status_experimental_metrics_average-wait-time\") FROM \"httpjson_puppet_stats\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
-              "rawQuery": false,
-              "refId": "D",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-wait-time"
+                      "FiveMinuteRate"
                     ],
                     "type": "field"
                   },
@@ -306,7 +138,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Puppetserver Performance",
+          "title": "Command Persistence Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -323,15 +155,15 @@
           "yaxes": [
             {
               "format": "short",
-              "label": "jrubies - free, requested",
+              "label": null,
               "logBase": 1,
               "max": null,
               "min": null,
               "show": true
             },
             {
-              "format": "ms",
-              "label": "time - wait, borrow",
+              "format": "short",
+              "label": null,
               "logBase": 1,
               "max": null,
               "min": null,
@@ -360,10 +192,13 @@
           "fill": 1,
           "id": 2,
           "legend": {
+            "alignAsTable": false,
             "avg": false,
             "current": false,
+            "hideEmpty": false,
             "max": false,
             "min": false,
+            "rightSide": false,
             "show": true,
             "total": false,
             "values": false
@@ -371,32 +206,19 @@
           "lines": true,
           "linewidth": 1,
           "links": [],
-          "nullPointMode": "connected",
+          "nullPointMode": "null",
           "percentage": false,
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "uptime",
-              "yaxis": 2
-            },
-            {
-              "alias": "uptime",
-              "fill": 0
-            },
-            {
-              "alias": "heap used",
-              "fill": 4
-            }
-          ],
+          "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 12,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "alias": "heap committed",
+              "alias": "$tag_host",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -418,8 +240,7 @@
                   "type": "fill"
                 }
               ],
-              "hide": false,
-              "measurement": "httpjson_puppet_stats",
+              "measurement": "httpjson_puppetdb_PDBReadPool_pool_Usage",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -428,107 +249,7 @@
                 [
                   {
                     "params": [
-                      "status-service_status_experimental_jvm-metrics_heap-memory_committed"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "distinct"
-                  }
-                ]
-              ],
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/^$host$/"
-                }
-              ]
-            },
-            {
-              "alias": "heap used",
-              "dsType": "influxdb",
-              "groupBy": [
-                {
-                  "params": [
-                    "$__interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "host"
-                  ],
-                  "type": "tag"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "httpjson_puppet_stats",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "refId": "B",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "status-service_status_experimental_jvm-metrics_heap-memory_used"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "distinct"
-                  }
-                ]
-              ],
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/^$host$/"
-                }
-              ]
-            },
-            {
-              "alias": "uptime",
-              "dsType": "influxdb",
-              "groupBy": [
-                {
-                  "params": [
-                    "$__interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "host"
-                  ],
-                  "type": "tag"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "httpjson_puppet_stats",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "refId": "C",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "status-service_status_experimental_jvm-metrics_up-time-ms"
+                      "Mean"
                     ],
                     "type": "field"
                   },
@@ -550,7 +271,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Heap Memory and Uptime",
+          "title": "Read Pool Usage",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -566,7 +287,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -574,7 +295,7 @@
               "show": true
             },
             {
-              "format": "ms",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -582,19 +303,7 @@
               "show": true
             }
           ]
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 250,
-      "panels": [
+        },
         {
           "aliasColors": {},
           "bars": false,
@@ -622,7 +331,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 6,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -649,7 +358,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppet_stats",
+              "measurement": "httpjson_puppetdb_PDBReadPool_pool_Wait",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -658,7 +367,7 @@
                 [
                   {
                     "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-requested-jrubies"
+                      "Mean"
                     ],
                     "type": "field"
                   },
@@ -680,7 +389,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Average Requested Jrubies",
+          "title": "Read Pool Wait",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -740,7 +449,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 6,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -767,7 +476,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppet_stats",
+              "measurement": "httpjson_puppetdb_PDBReadPool_pool_PendingConnections",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -776,7 +485,7 @@
                 [
                   {
                     "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-borrow-time"
+                      "Value"
                     ],
                     "type": "field"
                   },
@@ -798,7 +507,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Average Borrow Time",
+          "title": "Read Pool Pending Connections",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -814,7 +523,7 @@
           },
           "yaxes": [
             {
-              "format": "ms",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -870,7 +579,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 6,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -897,7 +606,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppet_stats",
+              "measurement": "httpjson_puppetdb_PDBWritePool_pool_Usage",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -906,7 +615,7 @@
                 [
                   {
                     "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-free-jrubies"
+                      "Mean"
                     ],
                     "type": "field"
                   },
@@ -928,7 +637,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Average Free Jrubies",
+          "title": "Write Pool Usage",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -988,6 +697,254 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_host",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_PDBWritePool_pool_Wait",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "Mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Write Pool Wait",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 7,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_host",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_PDBWritePool_pool_PendingConnections",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "Value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Write Pool Pending Connections",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
@@ -1015,7 +972,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "httpjson_puppet_stats",
+              "measurement": "httpjson_puppetdb_global_discarded",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -1024,7 +981,7 @@
                 [
                   {
                     "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-wait-time"
+                      "OneMinuteRate"
                     ],
                     "type": "field"
                   },
@@ -1046,7 +1003,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Average Wait Time",
+          "title": "Global Discards",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1062,7 +1019,125 @@
           },
           "yaxes": [
             {
-              "format": "ms",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 9,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_host",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_global_fatal",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "OneMinuteRate"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Global Fatals",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1092,7 +1167,7 @@
   "style": "dark",
   "tags": [
     "telegraf",
-    "puppetserver"
+    "puppetdb"
   ],
   "templating": {
     "list": [
@@ -1148,6 +1223,6 @@
     ]
   },
   "timezone": "",
-  "title": "Telegraf Puppetserver Performance",
-  "version": 5
+  "title": "Telegraf PuppetDB Workload",
+  "version": 3
 }

--- a/manifests/dashboards/telegraf.pp
+++ b/manifests/dashboards/telegraf.pp
@@ -11,6 +11,14 @@ class pe_metrics_dashboard::dashboards::telegraf(
     require          => Grafana_datasource['influxdb_telegraf'],
   }
 
+  grafana_dashboard { 'Telegraf PuppetDB Workload':
+    grafana_url      => "http://localhost:${grafana_port}",
+    grafana_user     => 'admin',
+    grafana_password => $grafana_password,
+    content          => file('pe_metrics_dashboard/Telegraf_PuppetDB_Workload.json'),
+    require          => Grafana_datasource['influxdb_telegraf'],
+  }
+
   grafana_dashboard { 'Telegraf Puppetserver Performance':
     grafana_url      => "http://localhost:${grafana_port}",
     grafana_user     => 'admin',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -76,26 +76,9 @@ class pe_metrics_dashboard::install(
   }
 
   if $enable_telegraf {
-    package { 'telegraf':
-      ensure  => present,
-      require => Class['pe_metrics_dashboard::repos'],
-    }
-
-    if $configure_telegraf {
-
-      file {'/etc/telegraf/telegraf.conf':
-        ensure  => file,
-        owner   => 0,
-        group   => 0,
-        content => epp('pe_metrics_dashboard/telegraf.conf.epp'),
-        notify  => Service['telegraf'],
-      }
-    }
-
-    service { 'telegraf':
-      ensure  => running,
-      enable  => true,
-      require => [Package['telegraf'], Service[$influx_db_service_name]],
+    class { 'pe_metrics_dashboard::telegraf':
+      configure_telegraf     => $configure_telegraf,
+      influx_db_service_name => $influx_db_service_name,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class pe_metrics_dashboard::params {
 
   # Default Installation parameters
   $add_dashboard_examples =  false
-  $influxdb_database_name =  ["pe_metrics"]
+  $influxdb_database_name =  ['pe_metrics']
   $grafana_version        =  '4.5.2'
   $grafana_http_port      =  3000
   $influx_db_password     =  'puppet'
@@ -21,8 +21,8 @@ class pe_metrics_dashboard::params {
   $enable_chronograf      =  false
   # telegraf config
   $configure_telegraf     =  false
-  $master_list            =  []
-  $puppetdb_list          =  []
+  $master_list            =  [$::settings::certname]
+  $puppetdb_list          =  [$::settings::certname]
 
 
   case $::osfamily {

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -138,7 +138,7 @@ class pe_metrics_dashboard::telegraf (
       'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.Wait' },
   ]
 
-  $metrics = $::pe_server_version ? {
+  $puppetdb_metrics = $::pe_server_version ? {
     /^2015./ => $activemq_metrics,
     /^2016./ => $activemq_metrics + $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
     default  => $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
@@ -161,7 +161,8 @@ class pe_metrics_dashboard::telegraf (
       ensure  => file,
       owner   => 0,
       group   => 0,
-      content => epp('pe_metrics_dashboard/telegraf.conf.epp', {metrics => $metrics}),
+      content => epp('pe_metrics_dashboard/telegraf.conf.epp',
+        {puppetdb_metrics => $puppetdb_metrics}),
       notify  => Service['telegraf'],
       require => Package['telegraf'],
     }

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -1,0 +1,169 @@
+# == Class: pe_metrics_dashboard::telegraf: (
+#    Boolean $configure_telegraf - Add the telegraf config file
+#)
+#
+class pe_metrics_dashboard::telegraf (
+  Boolean $configure_telegraf         =  $pe_metrics_dashboard::params::configure_telegraf,
+  String $influx_db_service_name      =  $pe_metrics_dashboard::params::influx_db_service_name,
+  Array[String] $additional_metrics   = [],
+  ) {
+
+  # Stolen from https://github.com/npwalker/pe_metric_curl_cron_jobs/blob/master/manifests/puppetdb.pp
+  # Configure the mbean metrics to be collected
+  $activemq_metrics = [
+  { 'name' => 'amq_metrics',
+    'url'  => 'org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=puppetlabs.puppetdb.commands' },
+  ]
+
+  $base_metrics = [
+    { 'name' => 'global_command-parse-time',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.command-parse-time' },
+    { 'name' => 'global_discarded',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.discarded' },
+    { 'name' => 'global_fatal',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.fatal' },
+    { 'name' => 'global_generate-retry-message-time',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.generate-retry-message-time' },
+    { 'name' => 'global_message-persistence-time',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.message-persistence-time' },
+    { 'name' => 'global_retried',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.retried' },
+    { 'name' => 'global_retry-counts',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.retry-counts' },
+    { 'name' => 'global_retry-persistence-time',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.retry-persistence-time' },
+    { 'name' => 'global_seen',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.seen' },
+    { 'name' => 'global_processed',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.processed' },
+    { 'name' => 'global_processing-time',
+      'url'  => 'puppetlabs.puppetdb.mq:name=global.processing-time' },
+  ]
+
+  $storage_metrics = [
+    { 'name' => 'storage_add-edges',
+      'url'  => 'puppetlabs.puppetdb.storage:name=add-edges' },
+    { 'name' => 'storage_add-resources',
+      'url'  => 'puppetlabs.puppetdb.storage:name=add-resources' },
+    { 'name' => 'storage_catalog-hash',
+      'url'  => 'puppetlabs.puppetdb.storage:name=catalog-hash' },
+    { 'name' => 'storage_catalog-hash-match-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=catalog-hash-match-time' },
+    { 'name' => 'storage_catalog-hash-miss-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=catalog-hash-miss-time' },
+    { 'name' => 'storage_gc-catalogs-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=gc-catalogs-time' },
+    { 'name' => 'storage_gc-environments-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=gc-environments-time' },
+    { 'name' => 'storage_gc-fact-paths',
+      'url'  => 'puppetlabs.puppetdb.storage:name=gc-fact-paths' },
+    { 'name' => 'storage_gc-params-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=gc-params-time' },
+    { 'name' => 'storage_gc-report-statuses',
+      'url'  => 'puppetlabs.puppetdb.storage:name=gc-report-statuses' },
+    { 'name' => 'storage_gc-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=gc-time' },
+    { 'name' => 'storage_new-catalog-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=new-catalog-time' },
+    { 'name' => 'storage_new-catalogs',
+      'url'  => 'puppetlabs.puppetdb.storage:name=new-catalogs' },
+    { 'name' => 'storage_replace-catalog-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=replace-catalog-time' },
+    { 'name' => 'storage_replace-facts-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=replace-facts-time' },
+    { 'name' => 'storage_resource-hashes',
+      'url'  => 'puppetlabs.puppetdb.storage:name=resource-hashes' },
+    { 'name' => 'storage_store-report-time',
+      'url'  => 'puppetlabs.puppetdb.storage:name=store-report-time' },
+  ]
+
+  #TODO: Track these on a less frequent cadence because they are slow to run
+  $storage_metrics_db_queries = [
+    { 'name' => 'storage_catalog-volitilty',
+      'url'  => 'puppetlabs.puppetdb.storage:name=catalog-volitilty' },
+    { 'name' => 'storage_duplicate-catalogs',
+      'url'  => 'puppetlabs.puppetdb.storage:name=duplicate-catalogs' },
+    { 'name' => 'storage_duplicate-pct',
+      'url'  => 'puppetlabs.puppetdb.storage:name=duplicate-pct' },
+  ]
+
+  $numbers = $::pe_server_version ? {
+    /^2015.2/     => {'catalogs' => 6, 'facts' => 4, 'reports' => 6},
+    /^2015.3/     => {'catalogs' => 7, 'facts' => 4, 'reports' => 6},
+    /^2016.(1|2)/ => {'catalogs' => 8, 'facts' => 4, 'reports' => 7},
+    /^2016.(4|5)/ => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
+    /^2017.(1|2)/ => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
+    default       => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
+  }
+
+  $version_specific_metrics = [
+    { 'name' => 'mq_replace_catalog_retried',
+      'url'  => "puppetlabs.puppetdb.mq:name=replace catalog.${numbers['catalogs']}.retried" },
+    { 'name' => 'mq_replace_catalog_retry-counts',
+      'url'  => "puppetlabs.puppetdb.mq:name=replace catalog.${numbers['catalogs']}.retry-counts" },
+    { 'name' => 'mq_replace_facts_retried',
+      'url'  => "puppetlabs.puppetdb.mq:name=replace facts.${numbers['facts']}.retried" },
+    { 'name' => 'mq_replace_facts_retry-counts',
+      'url'  => "puppetlabs.puppetdb.mq:name=replace facts.${numbers['facts']}.retry-counts" },
+    { 'name' => 'mq_store_report_retried',
+      'url'  => "puppetlabs.puppetdb.mq:name=store report.${numbers['reports']}.retried" },
+    { 'name' => 'mq_store_reports_retry-counts',
+      'url'  => "puppetlabs.puppetdb.mq:name=store report.${numbers['reports']}.retry-counts" },
+  ]
+
+  $connection_pool_metrics = [
+    { 'name' => 'PDBReadPool_pool_ActiveConnections',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.ActiveConnections' },
+    { 'name' => 'PDBReadPool_pool_IdleConnections',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.IdleConnections' },
+    { 'name' => 'PDBReadPool_pool_PendingConnections',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.PendingConnections' },
+    { 'name' => 'PDBReadPool_pool_TotalConnections',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.TotalConnections' },
+    { 'name' => 'PDBReadPool_pool_Usage',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.Usage' },
+    { 'name' => 'PDBReadPool_pool_Wait',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.Wait' },
+    { 'name' => 'PDBWritePool_pool_ActiveConnections',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.ActiveConnections' },
+    { 'name' => 'PDBWritePool_pool_IdleConnections',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.IdleConnections' },
+    { 'name' => 'PDBWritePool_pool_PendingConnections',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.PendingConnections' },
+    { 'name' => 'PDBWritePool_pool_TotalConnections',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.TotalConnections' },
+    { 'name' => 'PDBWritePool_pool_Usage',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.Usage' },
+    { 'name' => 'PDBWritePool_pool_Wait',
+      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.Wait' },
+  ]
+
+  $metrics = $::pe_server_version ? {
+    /^2015./ => $activemq_metrics,
+    /^2016./ => $activemq_metrics + $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
+    default  => $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
+  }
+
+  package { 'telegraf':
+    ensure  => present,
+    require => Class['pe_metrics_dashboard::repos'],
+  }
+
+  service { 'telegraf':
+    ensure  => running,
+    enable  => true,
+    require => [Package['telegraf'], Service[$influx_db_service_name]],
+  }
+
+  if $configure_telegraf {
+
+    file {'/etc/telegraf/telegraf.conf':
+      ensure  => file,
+      owner   => 0,
+      group   => 0,
+      content => epp('pe_metrics_dashboard/telegraf.conf.epp', {metrics => $metrics}),
+      notify  => Service['telegraf'],
+      require => Package['telegraf'],
+    }
+  }
+}

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -49,8 +49,8 @@
   insecure_skip_verify = true
 
 <%# -%>
-<% unless $pe_metrics_dashboard::telegraf::metrics.empty {-%>
-<% $pe_metrics_dashboard::telegraf::metrics.each | $metric| {-%>
+<% unless $puppetdb_metrics.empty {-%>
+<% $puppetdb_metrics.each | $metric| {-%>
 [[inputs.httpjson]]
   name = "puppetdb_<%= $metric['name'] %>"
   servers = [

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -33,6 +33,7 @@
   ]
   method = "GET"
   insecure_skip_verify = true
+
 [[inputs.httpjson]]
   name = "puppetdb_command_queue"
   servers = [
@@ -47,68 +48,23 @@
   method = "GET"
   insecure_skip_verify = true
 
+<%# -%>
+<% unless $pe_metrics_dashboard::telegraf::metrics.empty {-%>
+<% $pe_metrics_dashboard::telegraf::metrics.each | $metric| {-%>
 [[inputs.httpjson]]
-  name = "puppetdb_command_global_processed"
+  name = "puppetdb_<%= $metric['name'] %>"
   servers = [
     <%# -%>
     <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
-    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
-    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq:name=global.processed",
+    <% $pe_metrics_dashboard::install::puppetdb_list.each |$master_list| {-%>
+    "https://<%= $master_list %>:8081/metrics/v1/mbeans/<%= $metric['url'] %>",
     <% } -%>
     <% } -%>
     <%# -%>
-            ]
+  ]
   method = "GET"
   insecure_skip_verify = true
-[[inputs.httpjson]]
-  name = "puppetdb_command_global_processing_time"
-  servers = [
-    <%# -%>
-    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
-    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
-    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dreplace+facts.5.processing-time",
-    <% } -%>
-    <% } -%>
-    <%# -%>
-            ]
-  method = "GET"
-  insecure_skip_verify = true
-[[inputs.httpjson]]
-  name = "puppetdb_command_catalog_processing"
-  servers = [
-    <%# -%>
-    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
-    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
-    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dreplace+catalog.9.processing-time",
-    <% } -%>
-    <% } -%>
-    <%# -%>
-            ]
-  method = "GET"
-  insecure_skip_verify = true
-[[inputs.httpjson]]
-  name = "puppetdb_command_fact_processing"
-  servers = [
-    <%# -%>
-    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
-    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
-    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dreplace+facts.5.processing-time",
-    <% } -%>
-    <% } -%>
-    <%# -%>
-            ]
-  method = "GET"
-  insecure_skip_verify = true
-[[inputs.httpjson]]
-  name = "puppetdb_command_report_storage"
-  servers = [
-    <%# -%>
-    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
-    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
-    "https://<%= $puppetdb_list %>:8081/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dstore+report.8.processing-time",
-    <% } -%>
-    <% } -%>
-    <%# -%>
-            ]
-  method = "GET"
-  insecure_skip_verify = true
+
+<% } -%>
+<% } -%>
+<%# -%>


### PR DESCRIPTION
This PR adds all of the PuppetDB metrics to telegraf and updates the dashboards. The following changes have been made to the dashboards. 

* All dashboard now have links between the same data source
* Dashboards have been tagged
* Telegraf dashboard now have a filter based on host
* Added PuppetDB workload dashboard
* Updated PuppetDB performance dashboard to the new telegraf metrics

A new telegraf class has been added to manage mbeans for puppetdb. (Mostly stolen from npwalker-pe_metric_curl_cron_jobs)