### PR TITLE
Update variables for the telegraf dashboards

### DIFF
--- a/files/Telegraf_PuppetDB_Performance.json
+++ b/files/Telegraf_PuppetDB_Performance.json
@@ -88,7 +88,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -99,7 +99,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -131,9 +131,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -206,7 +206,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -217,7 +217,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -249,9 +249,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -336,7 +336,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -347,7 +347,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -379,9 +379,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -466,7 +466,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -477,7 +477,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -509,9 +509,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -584,7 +584,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -595,7 +595,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -627,9 +627,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -702,7 +702,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -713,7 +713,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -745,9 +745,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -810,14 +810,14 @@
         "current": {},
         "datasource": "influxdb_telegraf",
         "hide": 0,
-        "includeAll": false,
-        "label": "Host",
-        "multi": false,
-        "name": "host",
+        "includeAll": true,
+        "label": "Server",
+        "multi": true,
+        "name": "server",
         "options": [],
-        "query": "SHOW TAG VALUES WITH KEY = \"host\"",
+        "query": "SHOW TAG VALUES WITH KEY = \"server\"",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^https://([^:]+):/",
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],

--- a/files/Telegraf_PuppetDB_Performance.json
+++ b/files/Telegraf_PuppetDB_Performance.json
@@ -88,7 +88,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -206,7 +205,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -336,7 +334,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -466,7 +463,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -584,7 +580,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -702,7 +697,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {

--- a/files/Telegraf_PuppetDB_Workload.json
+++ b/files/Telegraf_PuppetDB_Workload.json
@@ -85,7 +85,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -218,7 +217,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -336,7 +334,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -454,7 +451,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -584,7 +580,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -702,7 +697,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -820,7 +814,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -950,7 +943,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1068,7 +1060,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {

--- a/files/Telegraf_PuppetDB_Workload.json
+++ b/files/Telegraf_PuppetDB_Workload.json
@@ -85,7 +85,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -96,7 +96,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -128,9 +128,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -218,7 +218,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -229,7 +229,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -261,9 +261,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -336,7 +336,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -347,7 +347,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -379,9 +379,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -454,7 +454,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -465,7 +465,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -497,9 +497,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -584,7 +584,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -595,7 +595,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -627,9 +627,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -702,7 +702,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -713,7 +713,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -745,9 +745,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -820,7 +820,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -831,7 +831,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -863,9 +863,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -950,7 +950,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -961,7 +961,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -993,9 +993,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -1068,7 +1068,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1079,7 +1079,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -1111,9 +1111,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -1176,14 +1176,14 @@
         "current": {},
         "datasource": "influxdb_telegraf",
         "hide": 0,
-        "includeAll": false,
-        "label": "Host",
-        "multi": false,
-        "name": "host",
+        "includeAll": true,
+        "label": "server",
+        "multi": true,
+        "name": "server",
         "options": [],
-        "query": "SHOW TAG VALUES WITH KEY = \"host\"",
+        "query": "SHOW TAG VALUES WITH KEY = \"server\"",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^https://([^:]+):/",
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],

--- a/files/Telegraf_Puppetserver_Performance.json
+++ b/files/Telegraf_Puppetserver_Performance.json
@@ -95,7 +95,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server-ave. free jrubies",
+              "alias": "ave-free-jrubies",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -147,7 +147,7 @@
               ]
             },
             {
-              "alias": "$tag_server-ave. requested jrubies",
+              "alias": "ave-requested-jrubies",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -199,7 +199,7 @@
               ]
             },
             {
-              "alias": "$tag_server-ave-borrow-time",
+              "alias": "ave-borrow-time",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -251,7 +251,7 @@
               ]
             },
             {
-              "alias": "$tag_server-ave-wait-time",
+              "alias": "ave-wait-time",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -627,7 +627,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -745,7 +744,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -875,7 +873,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -993,7 +990,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {

--- a/files/Telegraf_Puppetserver_Performance.json
+++ b/files/Telegraf_Puppetserver_Performance.json
@@ -95,7 +95,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host-ave. free jrubies",
+              "alias": "$tag_server-ave. free jrubies",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -106,7 +106,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -140,14 +140,14 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             },
             {
-              "alias": "$tag_host-ave. requested jrubies",
+              "alias": "$tag_server-ave. requested jrubies",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -158,7 +158,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -192,14 +192,14 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             },
             {
-              "alias": "$tag_host-ave-borrow-time",
+              "alias": "$tag_server-ave-borrow-time",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -210,7 +210,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -244,14 +244,14 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             },
             {
-              "alias": "$tag_host-ave-wait-time",
+              "alias": "$tag_server-ave-wait-time",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -262,7 +262,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -296,9 +296,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -407,7 +407,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -440,9 +440,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             },
@@ -458,7 +458,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -490,9 +490,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             },
@@ -508,7 +508,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -540,9 +540,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -627,7 +627,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -638,7 +638,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -670,9 +670,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -745,7 +745,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -756,7 +756,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -788,9 +788,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -875,7 +875,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -886,7 +886,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -918,9 +918,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -993,7 +993,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "$tag_host",
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1004,7 +1004,7 @@
                 },
                 {
                   "params": [
-                    "host"
+                    "server"
                   ],
                   "type": "tag"
                 },
@@ -1036,9 +1036,9 @@
               ],
               "tags": [
                 {
-                  "key": "host",
+                  "key": "server",
                   "operator": "=~",
-                  "value": "/^$host$/"
+                  "value": "/$server/"
                 }
               ]
             }
@@ -1101,14 +1101,14 @@
         "current": {},
         "datasource": "influxdb_telegraf",
         "hide": 0,
-        "includeAll": false,
-        "label": "Host",
-        "multi": false,
-        "name": "host",
+        "includeAll": true,
+        "label": "server",
+        "multi": true,
+        "name": "server",
         "options": [],
-        "query": "SHOW TAG VALUES WITH KEY = \"host\"",
+        "query": "SHOW TAG VALUES WITH KEY = \"server\"",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^https://([^:]+):/",
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],


### PR DESCRIPTION
Prior to this commit the filter was using the `$host`, which was
actually the grafana host instead of the server as seen in #24 . This commit changes
this to use the server name pulled from the URL of the mbean.

An unintended side effect of this PR is that the alias (label) for the metrics is now the URL instead of the server name. I cannot come up with a way to denote the server name instead of the URL without a tagged server name. Let me know if you have any ideas on this. 