### PR TITLE
Add filtering tags for the archive dashboards

### DIFF
--- a/files/PuppetDB_Performance.json
+++ b/files/PuppetDB_Performance.json
@@ -86,6 +86,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -93,6 +94,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -120,7 +127,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -191,6 +204,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -198,6 +212,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -225,7 +245,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -308,6 +334,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -315,6 +342,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -342,7 +375,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -425,6 +464,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -432,6 +472,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -459,7 +505,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -530,6 +582,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -537,6 +590,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -564,7 +623,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -635,6 +700,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -642,6 +708,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -669,7 +741,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -723,7 +801,28 @@
     "archive"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "influxdb_pe_metrics",
+        "hide": 0,
+        "includeAll": true,
+        "label": "server",
+        "multi": true,
+        "name": "server",
+        "options": [],
+        "query": "SHOW TAG VALUES WITH KEY = \"server\"",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-1h",
@@ -756,5 +855,5 @@
   },
   "timezone": "",
   "title": "Archive PuppetDB Performance",
-  "version": 5
+  "version": 11
 }

--- a/files/PuppetDB_Workload.json
+++ b/files/PuppetDB_Workload.json
@@ -87,6 +87,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -127,7 +128,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -210,6 +217,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -250,7 +258,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -321,6 +335,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -361,7 +376,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -432,6 +453,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -472,7 +494,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -555,6 +583,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -589,7 +618,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -660,6 +695,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -667,6 +703,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -694,7 +736,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -765,6 +813,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -772,6 +821,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -799,7 +854,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -882,6 +943,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -889,6 +951,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -916,7 +984,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -987,6 +1061,7 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "$tag_server",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -994,6 +1069,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -1021,7 +1102,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -1075,7 +1162,28 @@
     "archive"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "influxdb_pe_metrics",
+        "hide": 0,
+        "includeAll": true,
+        "label": "server",
+        "multi": true,
+        "name": "server",
+        "options": [],
+        "query": "SHOW TAG VALUES WITH KEY = \"server\"",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-1h",
@@ -1108,5 +1216,5 @@
   },
   "timezone": "",
   "title": "Archive PuppetDB Workload",
-  "version": 4
+  "version": 9
 }

--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -106,14 +106,23 @@
                 },
                 {
                   "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
                 }
               ],
+              "hide": false,
               "measurement": "puppetserver.pe-jruby-metrics.average-free-jrubies",
               "orderByTime": "ASC",
               "policy": "default",
+              "query": "SELECT distinct(\"average-free-jrubies\") FROM \"puppetserver.pe-jruby-metrics.average-free-jrubies\" WHERE $timeFilter GROUP BY time(10s) fill(null)",
+              "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
               "select": [
@@ -130,7 +139,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             },
             {
               "alias": "ave. requested jrubies",
@@ -141,6 +156,12 @@
                     "10s"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -168,7 +189,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             },
             {
               "alias": "average-wait-time",
@@ -206,7 +233,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             },
             {
               "alias": "average-borrow-time",
@@ -244,7 +277,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -356,6 +395,12 @@
                 },
                 {
                   "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
@@ -380,7 +425,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             },
             {
               "alias": "heap commited",
@@ -391,6 +442,12 @@
                     "$__interval"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -418,7 +475,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             },
             {
               "alias": "uptime",
@@ -429,6 +492,12 @@
                     "10s"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -456,7 +525,13 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
@@ -550,6 +625,12 @@
                 },
                 {
                   "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
@@ -574,13 +655,19 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "average-requested-jrubies",
+          "title": "Average Requested Jrubies",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -656,6 +743,12 @@
                 },
                 {
                   "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
@@ -680,13 +773,19 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "ave-borrow-time",
+          "title": "Average Borrow Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -774,6 +873,12 @@
                 },
                 {
                   "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
@@ -798,13 +903,19 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "ave-free-jrubies",
+          "title": "Average Free Jrubies",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -880,6 +991,12 @@
                 },
                 {
                   "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"
@@ -904,13 +1021,19 @@
                   }
                 ]
               ],
-              "tags": []
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "ave-wait-time",
+          "title": "Average Wait Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -958,7 +1081,28 @@
     "archive"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "influxdb_pe_metrics",
+        "hide": 0,
+        "includeAll": true,
+        "label": "server",
+        "multi": true,
+        "name": "server",
+        "options": [],
+        "query": "SHOW TAG VALUES WITH KEY = \"server\"",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-1h",
@@ -991,5 +1135,5 @@
   },
   "timezone": "",
   "title": "Archive Puppetserver Performance",
-  "version": 4
+  "version": 10
 }


### PR DESCRIPTION
Prior to this commit there was no templating of the metrics. This commit
adds a basic filter around the server tag for all of the Archive graphs.