### PR TITLE
Enable the option for SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ class { 'pe_metrics_dashboard::install':
 
 *requires enabling on the master side as described [here](https://puppet.com/docs/pe/2017.3/puppet_server_metrics/getting_started_with_graphite.html#enabling-puppet-server-graphite-support)
 
+#### Enable SSL
+
+```
+class { 'pe_metrics_dashboard::install':
+  use_dashboard_ssl => true,
+}
+```
+
+By default, this will create a set of certificates in `/etc/grafana` that are based on Puppet's agent certificates.  You can also specify a different location by passing the variables below, but managing the certificate content or supplying your own certificates isn't yet supported. 
+
+  `dashboard_cert_file`
+  `dashboard_cert_key`
+
 #### Other possibilities
 
 ```

--- a/manifests/dashboards/graphite.pp
+++ b/manifests/dashboards/graphite.pp
@@ -1,10 +1,18 @@
 class pe_metrics_dashboard::dashboards::graphite(
-  Integer $grafana_port     =  $pe_metrics_dashboard::params::grafana_http_port,
-  String $grafana_password  =  $pe_metrics_dashboard::params::grafana_password,
+  Integer $grafana_port       =  $pe_metrics_dashboard::params::grafana_http_port,
+  String $grafana_password    =  $pe_metrics_dashboard::params::grafana_password,
+  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::params::use_dashboard_ssl,
 ) inherits pe_metrics_dashboard::params {
 
+  if $use_dashboard_ssl {
+    $uri = 'https'
+  }
+  else {
+    $uri = 'http'
+  }
+
   grafana_dashboard { 'Graphite Puppetserver Performance':
-    grafana_url      => "http://localhost:${grafana_port}",
+    grafana_url      => "${uri}://localhost:${grafana_port}",
     grafana_user     => 'admin',
     grafana_password => $grafana_password,
     content          => file('pe_metrics_dashboard/Graphite_Puppetserver_Performance.json'),

--- a/manifests/dashboards/pe_metrics.pp
+++ b/manifests/dashboards/pe_metrics.pp
@@ -1,10 +1,18 @@
 class pe_metrics_dashboard::dashboards::pe_metrics(
-  Integer $grafana_port     =  $pe_metrics_dashboard::params::grafana_http_port,
-  String $grafana_password  =  $pe_metrics_dashboard::params::grafana_password,
+  Integer $grafana_port       =  $pe_metrics_dashboard::params::grafana_http_port,
+  String $grafana_password    =  $pe_metrics_dashboard::params::grafana_password,
+  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::params::use_dashboard_ssl,
 ) inherits pe_metrics_dashboard::params {
 
+  if $use_dashboard_ssl {
+    $uri = 'https'
+  }
+  else {
+    $uri = 'http'
+  }
+
   grafana_dashboard { 'Archive PuppetDB Performance':
-    grafana_url      => "http://localhost:${grafana_port}",
+    grafana_url      => "${uri}://localhost:${grafana_port}",
     grafana_user     => 'admin',
     grafana_password => $grafana_password,
     content          => file('pe_metrics_dashboard/PuppetDB_Performance.json'),
@@ -12,7 +20,7 @@ class pe_metrics_dashboard::dashboards::pe_metrics(
   }
 
   grafana_dashboard { 'Archive PuppetDB Workload':
-    grafana_url      => "http://localhost:${grafana_port}",
+    grafana_url      => "${uri}://localhost:${grafana_port}",
     grafana_user     => 'admin',
     grafana_password => $grafana_password,
     content          => file('pe_metrics_dashboard/PuppetDB_Workload.json'),
@@ -20,7 +28,7 @@ class pe_metrics_dashboard::dashboards::pe_metrics(
   }
 
   grafana_dashboard { 'Archive Puppetserver Performance':
-    grafana_url      => "http://localhost:${grafana_port}",
+    grafana_url      => "${uri}://localhost:${grafana_port}",
     grafana_user     => 'admin',
     grafana_password => $grafana_password,
     content          => file('pe_metrics_dashboard/Puppetserver_Performance.json'),

--- a/manifests/dashboards/telegraf.pp
+++ b/manifests/dashboards/telegraf.pp
@@ -1,10 +1,18 @@
 class pe_metrics_dashboard::dashboards::telegraf(
   Integer $grafana_port     =  $pe_metrics_dashboard::params::grafana_http_port,
   String $grafana_password  =  $pe_metrics_dashboard::params::grafana_password,
+  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::params::use_dashboard_ssl,
 ) inherits pe_metrics_dashboard::params {
 
+  if $use_dashboard_ssl {
+    $uri = 'https'
+  }
+  else {
+    $uri = 'http'
+  }
+
   grafana_dashboard { 'Telegraf PuppetDB Performance':
-    grafana_url      => "http://localhost:${grafana_port}",
+    grafana_url      => "${uri}://localhost:${grafana_port}",
     grafana_user     => 'admin',
     grafana_password => $grafana_password,
     content          => file('pe_metrics_dashboard/Telegraf_PuppetDB_Performance.json'),
@@ -12,7 +20,7 @@ class pe_metrics_dashboard::dashboards::telegraf(
   }
 
   grafana_dashboard { 'Telegraf PuppetDB Workload':
-    grafana_url      => "http://localhost:${grafana_port}",
+    grafana_url      => "${uri}://localhost:${grafana_port}",
     grafana_user     => 'admin',
     grafana_password => $grafana_password,
     content          => file('pe_metrics_dashboard/Telegraf_PuppetDB_Workload.json'),
@@ -20,7 +28,7 @@ class pe_metrics_dashboard::dashboards::telegraf(
   }
 
   grafana_dashboard { 'Telegraf Puppetserver Performance':
-    grafana_url      => "http://localhost:${grafana_port}",
+    grafana_url      => "${uri}://localhost:${grafana_port}",
     grafana_user     => 'admin',
     grafana_password => $grafana_password,
     content          => file('pe_metrics_dashboard/Telegraf_Puppetserver_Performance.json'),

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -61,12 +61,15 @@ class pe_metrics_dashboard::install(
       owner  => 'grafana',
       mode   => "0400",
     }
+
+    $uri = 'https'
   }
   else {
     $cfg = { server    => {
                http_port => $grafana_http_port,
              },
 	   }
+    $uri = 'http'
   }
 
   service { $influx_db_service_name:
@@ -151,7 +154,7 @@ class pe_metrics_dashboard::install(
   # Configure grafana to use InfluxDB with any number of database names
   $influxdb_database_name.each |$db_name| {
     grafana_datasource { "influxdb_${db_name}":
-      grafana_url      => "http://localhost:${grafana_http_port}",
+      grafana_url      => "${uri}://localhost:${grafana_http_port}",
       type             => 'influxdb',
       database         => $db_name,
       url              => 'http://localhost:8086',
@@ -177,19 +180,22 @@ class pe_metrics_dashboard::install(
 
   if ($add_dashboard_examples) and ! $facts['overwrite_dashboards_disabled'] and ('pe_metrics' in $influxdb_database_name){
     class {'pe_metrics_dashboard::dashboards::pe_metrics':
-      grafana_port => $grafana_http_port,
+      grafana_port      => $grafana_http_port,
+      use_dashboard_ssl => $use_dashboard_ssl,
     }
   }
 
   if ($add_dashboard_examples) and ! $facts['overwrite_dashboards_disabled'] and ('telegraf' in $influxdb_database_name){
     class {'pe_metrics_dashboard::dashboards::telegraf':
-      grafana_port => $grafana_http_port,
+      grafana_port      => $grafana_http_port,
+      use_dashboard_ssl => $use_dashboard_ssl,
     }
   }
 
   if ($add_dashboard_examples) and ! $facts['overwrite_dashboards_disabled'] and ('graphite' in $influxdb_database_name){
     class {'pe_metrics_dashboard::dashboards::graphite':
-      grafana_port => $grafana_http_port,
+      grafana_port      => $grafana_http_port,
+      use_dashboard_ssl => $use_dashboard_ssl,
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -53,6 +53,7 @@ class pe_metrics_dashboard::install(
       source => "${facts['puppet_sslpaths']['certdir']['path']}/${clientcert}.pem",
       owner  => 'grafana',
       mode   => "0400",
+      require => Package['grafana'],
     }
 
     file { $dashboard_cert_key:
@@ -60,6 +61,7 @@ class pe_metrics_dashboard::install(
       source => "${facts['puppet_sslpaths']['privatekeydir']['path']}/${clientcert}.pem",
       owner  => 'grafana',
       mode   => "0400",
+      require => Package['grafana'],
     }
 
     $uri = 'https'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,8 +11,8 @@ class pe_metrics_dashboard::params {
   $add_dashboard_examples =  false
   $overwrite_dashboards   =  true
   $use_dashboard_ssl      = false 
-  $dashboard_cert_file    = "${facts['puppet_sslpaths']['certdir']['path']}/${clientcert}.pem"      
-  $dashboard_cert_key     = "${facts['puppet_sslpaths']['privatekeydir']['path']}/${clientcert}.pem"	
+  $dashboard_cert_file    = "/etc/grafana/${clientcert}_cert.pem"      
+  $dashboard_cert_key     = "/etc/grafana/${clientcert}_key.pem"	
   $influxdb_database_name =  ['pe_metrics']
   $grafana_version        =  '4.5.2'
   $grafana_http_port      =  3000

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,9 @@ class pe_metrics_dashboard::params {
   # Default Installation parameters
   $add_dashboard_examples =  false
   $overwrite_dashboards   =  true
+  $use_dashboard_ssl      = false 
+  $dashboard_cert_file    = "${facts['puppet_sslpaths']['certdir']['path']}/${clientcert}.pem"      
+  $dashboard_cert_key     = "${facts['puppet_sslpaths']['privatekeydir']['path']}/${clientcert}.pem"	
   $influxdb_database_name =  ['pe_metrics']
   $grafana_version        =  '4.5.2'
   $grafana_http_port      =  3000


### PR DESCRIPTION
This will allow you to configure grafana to serve over SSL.

It creates a set of certificates for this in `/etc/grafana`, and these are based on the Puppet agent's own certificates.  At some point, we should allow end-users to drop their own certificates in if they want.