### PR TITLE
(maint) Use pe_metrics_dashboard instead of pe_metrics_dashboard::install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # pe_metrics_dashboard
 
-#### Table of Contents
+## Table of Contents
 
 1. [Description](#description)
-1. [Setup - The basics of getting started with pe_metrics_dashboard](#setup)
-    * [What pe_metrics_dashboard affects](#what-pe_metrics_dashboard-affects)
-    * [Setup requirements](#setup-requirements)
-    * [Beginning with pe_metrics_dashboard](#beginning-with-pe_metrics_dashboard)
-1. [Usage - Configuration options and additional functionality](#usage)
-1. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
-1. [Limitations - OS compatibility, etc.](#limitations)
-1. [Development - Guide for contributing to the module](#development)
+2. [Setup - The basics of getting started with pe_metrics_dashboard](#setup)
+  * [What pe_metrics_dashboard affects](#what-pe_metrics_dashboard-affects)
+  * [Setup requirements](#setup-requirements)
+  * [Beginning with pe_metrics_dashboard](#beginning-with-pe_metrics_dashboard)
+3. [Usage - Configuration options and additional functionality](#usage)
+4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+5. [Limitations - OS compatibility, etc.](#limitations)
+6. [Development - Guide for contributing to the module](#development)
 
 ## Description
 
-This module is used to configure grafana, telegraf, and influxdb to consume metrics from Puppet Enterprise.  
+This module is used to configure grafana, telegraf, and influxdb to consume metrics from Puppet Enterprise.
 
 You have the option of getting metrics from any or all of three of these methods:
 
-* the [npwalker/pe_metric_curl_cron_jobs](https://forge.puppet.com/npwalker/pe_metric_curl_cron_jobs) module 
+* Through Archive files from the [npwalker/pe_metric_curl_cron_jobs](https://forge.puppet.com/npwalker/pe_metric_curl_cron_jobs) module
 * Natively, via Puppetserver's [built-in graphite support](https://puppet.com/docs/pe/2017.3/puppet_server_metrics/getting_started_with_graphite.html#enabling-puppet-server-graphite-support)
 * Through telegraf, which polls several of PE's metrics endpoints
 
@@ -26,7 +26,7 @@ You have the option of getting metrics from any or all of three of these methods
 
 ### Beginning with pe_metrics_dashboard
 
-#### Minimal configuration 
+#### Minimal configuration
 
 Configures grafana-server, influxdb, and telegraf, with an influxdb datasource and a database called "pe_metrics"
 
@@ -36,7 +36,7 @@ include pe_metrics_dashboard::install
 
 ## Usage
 
-#### To install example dashboards for each of the collection methods:
+### To install example dashboards for all of the collection methods:
 
 ```
 class { 'pe_metrics_dashboard::install':
@@ -45,9 +45,17 @@ class { 'pe_metrics_dashboard::install':
 }
 ```
 
-*add_dashboard_examples enforces state on the dashboards.  Remove this later if you want to make edits to the examples.
+* `add_dashboard_examples` enforces state on the dashboards. Remove this later if you want to make edits to the examples or add the `overwrite_dashboards` parameter to disable overwriting the dashboards after the first run.
 
-#### Configure telegraf for one or more masters / puppetdb nodes:
+```
+class { 'pe_metrics_dashboard::install':
+  add_dashboard_examples => true,
+  influxdb_database_name => ['pe_metrics','telegraf','graphite'],
+  overwrite_dashboards   => false,
+}
+```
+
+### Configure telegraf for one or more masters / puppetdb nodes:
 
 ```
 class { 'pe_metrics_dashboard::install':
@@ -57,7 +65,7 @@ class { 'pe_metrics_dashboard::install':
 }
 ```
 
-#### Enable Graphite support 
+### Enable Graphite support
 
 ```
 class { 'pe_metrics_dashboard::install':
@@ -65,9 +73,9 @@ class { 'pe_metrics_dashboard::install':
 }
 ```
 
-*requires enabling on the master side as described [here](https://puppet.com/docs/pe/2017.3/puppet_server_metrics/getting_started_with_graphite.html#enabling-puppet-server-graphite-support)
+* This setting requires enabling on the master side as described [here](https://puppet.com/docs/pe/2017.3/puppet_server_metrics/getting_started_with_graphite.html#enabling-puppet-server-graphite-support)
 
-#### Enable SSL
+### Enable SSL
 
 ```
 class { 'pe_metrics_dashboard::install':
@@ -75,12 +83,13 @@ class { 'pe_metrics_dashboard::install':
 }
 ```
 
-By default, this will create a set of certificates in `/etc/grafana` that are based on Puppet's agent certificates.  You can also specify a different location by passing the variables below, but managing the certificate content or supplying your own certificates isn't yet supported. 
+By default, this will create a set of certificates in `/etc/grafana` that are based on Puppet's agent certificates. You can also specify a different location by passing the variables below, but managing the certificate content or supplying your own certificates isn't yet supported.
 
-  `dashboard_cert_file`
-  `dashboard_cert_key`
+`dashboard_cert_file` `dashboard_cert_key`
 
-#### Other possibilities
+### Other possibilities
+
+Configure the passwords for the InfluxDB and Grafana administrator users and enable additional [TICK Stack](https://www.influxdata.com/time-series-platform/) components.
 
 ```
 class { 'pe_metrics_dashboard::install':
@@ -94,6 +103,168 @@ class { 'pe_metrics_dashboard::install':
 ```
 
 ## Reference
+
+### Classes
+
+#### Public classes
+
+* [`pe_metrics_dashboard::install`](#pe_metrics_dashboard_install): Installs and configures the Puppet Grafana dashboards and underlying connections.
+
+#### Private classes
+
+### Parameters
+
+#### pe_metrics_dashboard::install
+
+##### add_dashboard_examples
+
+Weather to add the Grafana dashboard example dashboards for the configured InfluxDB databases.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`.
+
+*Note:* These dashboards are managed and any changes will be overwritten unless the `overwrite_dashboards` is set to `false`.
+
+##### dashboard_cert_file
+
+The location of the Grafana certficiate.
+
+Defaults to `"/etc/grafana/${clientcert}_cert.pem"`
+
+##### dashboard_cert_key
+
+The location of the Grafana private key.
+
+Defaults to `"/etc/grafana/${clientcert}_key.pem"`
+
+##### configure_telegraf
+
+Weather to configure the telegraf service.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`
+
+This parameter enables configuring telegraf to query the `master_list` and `puppetdb_list` endpoints for metrics. Metrics will be stored in the `telegraf` database in InfluxDb. Ensure that `influxdb_database_name` contains `telegraf` when using this parameter.
+
+_Note:_ This parameter is only used if `enable_telegraf` is set to true.
+
+##### consume_graphite
+
+Weather to enable the InfluxDB Graphite plugin.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`
+
+This parameter enables the Graphite plugin for InfluxDB to allow for injesting Graphite metrics. Ensure `influxdb_database_name` contains `graphite` when using this parameter.
+
+*Note:* If using Graphite metrics from the Puppet Master, this needs to be set to `true`.
+
+##### grafana_http_port
+
+The port to run Grafana on.
+
+Valid values are Integers from `1024` to `65536`.
+
+Defaults to `3000`
+
+The grafana port for the web interface. This should be a nonprivileged port (above 1024).
+
+##### grafana_password
+
+The password for the Grafana admin user.
+
+Defaults to `'admin'`
+
+##### grafana_version
+
+The grafana version to install.
+
+Valid values are String versions of Grafana.
+
+Defaults to `'4.5.2'`
+
+##### influxdb_database_name
+
+An array of databases that should be created in InfluxDB.
+
+Valid values are 'pe_metrics','telegraf', 'graphite', and any other string.
+
+Defaults to `['pe_metrics']`
+
+Each database in the array will be created in InfluxDB. 'pe_metrics','telegraf', and 'graphite' are specially named and will be used with their associated metric collection method. Any other database name will be created, but not utilized with components in this module.
+
+##### influx_db_password
+
+The password for the InfluxDB admin user.
+
+Defaults to `'puppet'`
+
+##### enable_kapacitor
+
+Weather to install kapacitor.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`
+
+Install kapacitor. No configuration of kapacitor is included at this time.
+
+##### enable_chronograf
+
+Weather to install chronograf.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`
+
+Installs chronograf. No configuration of chronograf is included at this time.
+
+##### enable_telegraf
+
+Weather to install telegraf.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`
+
+Installs telegraf. No configuration is done unless the `configure_telegraf` parameter is set to `true`.
+
+##### master_list
+
+An array of Puppet Master servers to collect metrics from.
+
+Defaults to `["$::settings::certname"]`
+
+A list of Puppet master servers that will be configured for telegraf to query.
+
+##### overwrite_dashboards
+
+Weather to overwrite the example Grafana dashboards.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`
+
+This paramater disables overwriting the example Grafana dashboards. It takes effect after the second Puppet run and popultes the `overwrite_dashboards_disabled` fact. This only takes effect when `add_dashboard_examples` is set to true.
+
+##### puppetdb_list
+
+An array of PuppetDB servers to collect metrics from.
+
+Defaults to `["$::settings::certname"]`
+
+A list of PuppetDB servers that will be configured for telegraf to query.
+
+##### use_dashboard_ssl
+
+Weather to enable SSL on Grafana.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You have the option of getting metrics from any or all of three of these methods
 Configures grafana-server, influxdb, and telegraf, with an influxdb datasource and a database called "pe_metrics"
 
 ```
-include pe_metrics_dashboard::install
+include pe_metrics_dashboard
 ```
 
 ## Usage
@@ -39,7 +39,7 @@ include pe_metrics_dashboard::install
 ### To install example dashboards for all of the collection methods:
 
 ```
-class { 'pe_metrics_dashboard::install':
+class { 'pe_metrics_dashboard':
   add_dashboard_examples => true,
   influxdb_database_name => ['pe_metrics','telegraf','graphite'],
 }
@@ -48,7 +48,7 @@ class { 'pe_metrics_dashboard::install':
 * `add_dashboard_examples` enforces state on the dashboards. Remove this later if you want to make edits to the examples or add the `overwrite_dashboards` parameter to disable overwriting the dashboards after the first run.
 
 ```
-class { 'pe_metrics_dashboard::install':
+class { 'pe_metrics_dashboard':
   add_dashboard_examples => true,
   influxdb_database_name => ['pe_metrics','telegraf','graphite'],
   overwrite_dashboards   => false,
@@ -58,7 +58,7 @@ class { 'pe_metrics_dashboard::install':
 ### Configure telegraf for one or more masters / puppetdb nodes:
 
 ```
-class { 'pe_metrics_dashboard::install':
+class { 'pe_metrics_dashboard':
   configure_telegraf  => true,
   master_list         => ['master1.com','master2.com'],
   puppetdb_list       => ['puppetdb1','puppetdb2'],
@@ -68,7 +68,7 @@ class { 'pe_metrics_dashboard::install':
 ### Enable Graphite support
 
 ```
-class { 'pe_metrics_dashboard::install':
+class { 'pe_metrics_dashboard':
   consume_graphite   => true,
 }
 ```
@@ -78,7 +78,7 @@ class { 'pe_metrics_dashboard::install':
 ### Enable SSL
 
 ```
-class { 'pe_metrics_dashboard::install':
+class { 'pe_metrics_dashboard':
   use_dashboard_ssl => true,
 }
 ```
@@ -92,7 +92,7 @@ By default, this will create a set of certificates in `/etc/grafana` that are ba
 Configure the passwords for the InfluxDB and Grafana administrator users and enable additional [TICK Stack](https://www.influxdata.com/time-series-platform/) components.
 
 ```
-class { 'pe_metrics_dashboard::install':
+class { 'pe_metrics_dashboard':
   influx_db_password  => 'secret',
   grafana_password    => 'secret',
   grafana_http_port   => 8080,
@@ -108,13 +108,15 @@ class { 'pe_metrics_dashboard::install':
 
 #### Public classes
 
-* [`pe_metrics_dashboard::install`](#pe_metrics_dashboard_install): Installs and configures the Puppet Grafana dashboards and underlying connections.
+* [`pe_metrics_dashboard`](#pe_metrics_dashboard): Installs and configures the Puppet Grafana dashboards and underlying connections.
 
 #### Private classes
 
+* [`pe_metrics_dashboard::install`](#pe_metrics_dashboardinstall): Installs and configures the Puppet Grafana dashboards and underlying connections.
+
 ### Parameters
 
-#### pe_metrics_dashboard::install
+#### pe_metrics_dashboard
 
 ##### add_dashboard_examples
 
@@ -267,5 +269,20 @@ Valid values are `true`, `false`.
 Defaults to `false`
 
 ## Limitations
+
+### Repo failure for InfluxDB packages
+When installing InfluxDB on Centos/RedHat 6 or 7 you may encounter the following error message. This is due to a mismatch in the ciphers available on the local OS and on the InfluxDB repo.
+
+```
+Error: Execution of '/usr/bin/yum -d 0 -e 0 -y install telegraf' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: influxdb. Please verify its path and try again
+Error: /Stage[main]/Pe_metrics_dashboard::Telegraf/Package[telegraf]/ensure: change from purged to present failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install telegraf' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: influxdb. Please verify its path and try again
+```
+
+To recify the issue, please update `nss` and `curl` on the affected system.
+
+```
+yum install curl nss --disablerepo influxdb
+```
+
 
 ## Development

--- a/manifests/dashboards/graphite.pp
+++ b/manifests/dashboards/graphite.pp
@@ -1,8 +1,8 @@
 class pe_metrics_dashboard::dashboards::graphite(
-  Integer $grafana_port       =  $pe_metrics_dashboard::params::grafana_http_port,
-  String $grafana_password    =  $pe_metrics_dashboard::params::grafana_password,
-  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::params::use_dashboard_ssl,
-) inherits pe_metrics_dashboard::params {
+  Integer $grafana_port       =  $pe_metrics_dashboard::grafana_http_port,
+  String $grafana_password    =  $pe_metrics_dashboard::grafana_password,
+  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::use_dashboard_ssl,
+) {
 
   if $use_dashboard_ssl {
     $uri = 'https'

--- a/manifests/dashboards/pe_metrics.pp
+++ b/manifests/dashboards/pe_metrics.pp
@@ -1,8 +1,8 @@
 class pe_metrics_dashboard::dashboards::pe_metrics(
-  Integer $grafana_port       =  $pe_metrics_dashboard::params::grafana_http_port,
-  String $grafana_password    =  $pe_metrics_dashboard::params::grafana_password,
-  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::params::use_dashboard_ssl,
-) inherits pe_metrics_dashboard::params {
+  Integer $grafana_port       =  $pe_metrics_dashboard::grafana_http_port,
+  String $grafana_password    =  $pe_metrics_dashboard::grafana_password,
+  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::use_dashboard_ssl,
+) {
 
   if $use_dashboard_ssl {
     $uri = 'https'

--- a/manifests/dashboards/telegraf.pp
+++ b/manifests/dashboards/telegraf.pp
@@ -1,8 +1,8 @@
 class pe_metrics_dashboard::dashboards::telegraf(
-  Integer $grafana_port     =  $pe_metrics_dashboard::params::grafana_http_port,
-  String $grafana_password  =  $pe_metrics_dashboard::params::grafana_password,
-  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::params::use_dashboard_ssl,
-) inherits pe_metrics_dashboard::params {
+  Integer $grafana_port     =  $pe_metrics_dashboard::grafana_http_port,
+  String $grafana_password  =  $pe_metrics_dashboard::grafana_password,
+  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::use_dashboard_ssl,
+) {
 
   if $use_dashboard_ssl {
     $uri = 'https'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,47 @@
 #
 # Copyright 2017 Your name here, unless otherwise noted.
 #
-class pe_metrics_dashboard {
+class pe_metrics_dashboard (
+  Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::params::add_dashboard_examples,
+  Boolean $use_dashboard_ssl              =  $pe_metrics_dashboard::params::use_dashboard_ssl,
+  String $dashboard_cert_file             =  $pe_metrics_dashboard::params::dashboard_cert_file,
+  String $dashboard_cert_key              =  $pe_metrics_dashboard::params::dashboard_cert_key,
+  Boolean $overwrite_dashboards           =  $pe_metrics_dashboard::params::overwrite_dashboards,
+  String $overwrite_dashboards_file       =  $pe_metrics_dashboard::params::overwrite_dashboards_file,
+  String $influx_db_service_name          =  $pe_metrics_dashboard::params::influx_db_service_name,
+  Array[String] $influxdb_database_name   =  $pe_metrics_dashboard::params::influxdb_database_name,
+  String $grafana_version                 =  $pe_metrics_dashboard::params::grafana_version,
+  Integer $grafana_http_port              =  $pe_metrics_dashboard::params::grafana_http_port,
+  String $influx_db_password              =  $pe_metrics_dashboard::params::influx_db_password,
+  String $grafana_password                =  $pe_metrics_dashboard::params::grafana_password,
+  Boolean $enable_kapacitor               =  $pe_metrics_dashboard::params::enable_kapacitor,
+  Boolean $enable_chronograf              =  $pe_metrics_dashboard::params::enable_chronograf,
+  Boolean $enable_telegraf                =  $pe_metrics_dashboard::params::enable_telegraf,
+  Boolean $configure_telegraf             =  $pe_metrics_dashboard::params::configure_telegraf,
+  Boolean $consume_graphite               =  $pe_metrics_dashboard::params::consume_graphite,
+  Array[String] $master_list              =  $pe_metrics_dashboard::params::master_list,
+  Array[String] $puppetdb_list            =  $pe_metrics_dashboard::params::puppetdb_list
+) inherits pe_metrics_dashboard::params {
 
+  class { 'pe_metrics_dashboard::install':
+    add_dashboard_examples    =>  $add_dashboard_examples,
+    use_dashboard_ssl         =>  $use_dashboard_ssl,
+    dashboard_cert_file       =>  $dashboard_cert_file,
+    dashboard_cert_key        =>  $dashboard_cert_key,
+    overwrite_dashboards      =>  $overwrite_dashboards,
+    overwrite_dashboards_file =>  $overwrite_dashboards_file,
+    influx_db_service_name    =>  $influx_db_service_name,
+    influxdb_database_name    =>  $influxdb_database_name,
+    grafana_version           =>  $grafana_version,
+    grafana_http_port         =>  $grafana_http_port,
+    influx_db_password        =>  $influx_db_password,
+    grafana_password          =>  $grafana_password,
+    enable_kapacitor          =>  $enable_kapacitor,
+    enable_chronograf         =>  $enable_chronograf,
+    enable_telegraf           =>  $enable_telegraf,
+    configure_telegraf        =>  $configure_telegraf,
+    consume_graphite          =>  $consume_graphite,
+    master_list               =>  $master_list,
+    puppetdb_list             =>  $puppetdb_list,
+  }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,24 +1,24 @@
 class pe_metrics_dashboard::install(
-  Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::params::add_dashboard_examples,
-  Boolean $use_dashboard_ssl		  =  $pe_metrics_dashboard::params::use_dashboard_ssl,
-  String $dashboard_cert_file             =  $pe_metrics_dashboard::params::dashboard_cert_file,
-  String $dashboard_cert_key		  =  $pe_metrics_dashboard::params::dashboard_cert_key,
-  Boolean $overwrite_dashboards           =  $pe_metrics_dashboard::params::overwrite_dashboards,
-  String $overwrite_dashboards_file       =  $pe_metrics_dashboard::params::overwrite_dashboards_file,
-  String $influx_db_service_name          =  $pe_metrics_dashboard::params::influx_db_service_name,
-  Array[String] $influxdb_database_name   =  $pe_metrics_dashboard::params::influxdb_database_name,
-  String $grafana_version                 =  $pe_metrics_dashboard::params::grafana_version,
-  Integer $grafana_http_port              =  $pe_metrics_dashboard::params::grafana_http_port,
-  String $influx_db_password              =  $pe_metrics_dashboard::params::influx_db_password,
-  String $grafana_password                =  $pe_metrics_dashboard::params::grafana_password,
-  Boolean $enable_kapacitor               =  $pe_metrics_dashboard::params::enable_kapacitor,
-  Boolean $enable_chronograf              =  $pe_metrics_dashboard::params::enable_chronograf,
-  Boolean $enable_telegraf                =  $pe_metrics_dashboard::params::enable_telegraf,
-  Boolean $configure_telegraf             =  $pe_metrics_dashboard::params::configure_telegraf,
-  Boolean $consume_graphite               =  $pe_metrics_dashboard::params::consume_graphite,
-  Array[String] $master_list              =  $pe_metrics_dashboard::params::master_list,
-  Array[String] $puppetdb_list            =  $pe_metrics_dashboard::params::puppetdb_list
-) inherits pe_metrics_dashboard::params {
+  Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::add_dashboard_examples,
+  Boolean $use_dashboard_ssl              =  $pe_metrics_dashboard::use_dashboard_ssl,
+  String $dashboard_cert_file             =  $pe_metrics_dashboard::dashboard_cert_file,
+  String $dashboard_cert_key              =  $pe_metrics_dashboard::dashboard_cert_key,
+  Boolean $overwrite_dashboards           =  $pe_metrics_dashboard::overwrite_dashboards,
+  String $overwrite_dashboards_file       =  $pe_metrics_dashboard::overwrite_dashboards_file,
+  String $influx_db_service_name          =  $pe_metrics_dashboard::influx_db_service_name,
+  Array[String] $influxdb_database_name   =  $pe_metrics_dashboard::influxdb_database_name,
+  String $grafana_version                 =  $pe_metrics_dashboard::grafana_version,
+  Integer $grafana_http_port              =  $pe_metrics_dashboard::grafana_http_port,
+  String $influx_db_password              =  $pe_metrics_dashboard::influx_db_password,
+  String $grafana_password                =  $pe_metrics_dashboard::grafana_password,
+  Boolean $enable_kapacitor               =  $pe_metrics_dashboard::enable_kapacitor,
+  Boolean $enable_chronograf              =  $pe_metrics_dashboard::enable_chronograf,
+  Boolean $enable_telegraf                =  $pe_metrics_dashboard::enable_telegraf,
+  Boolean $configure_telegraf             =  $pe_metrics_dashboard::configure_telegraf,
+  Boolean $consume_graphite               =  $pe_metrics_dashboard::consume_graphite,
+  Array[String] $master_list              =  $pe_metrics_dashboard::master_list,
+  Array[String] $puppetdb_list            =  $pe_metrics_dashboard::puppetdb_list
+) {
 
   include pe_metrics_dashboard::repos
 
@@ -41,26 +41,26 @@ class pe_metrics_dashboard::install(
 
   if $use_dashboard_ssl {
     $cfg = { server    => {
-               http_port => $grafana_http_port,
-               protocol  => 'https',
-               cert_file => $dashboard_cert_file,
-               cert_key  => $dashboard_cert_key,
-             },
-	   }
+              http_port => $grafana_http_port,
+              protocol  => 'https',
+              cert_file => $dashboard_cert_file,
+              cert_key  => $dashboard_cert_key,
+            },
+    }
 
     file { $dashboard_cert_file:
-      ensure => present,
-      source => "${facts['puppet_sslpaths']['certdir']['path']}/${clientcert}.pem",
-      owner  => 'grafana',
-      mode   => "0400",
+      ensure  => present,
+      source  => "${facts['puppet_sslpaths']['certdir']['path']}/${clientcert}.pem",
+      owner   => 'grafana',
+      mode    => '0400',
       require => Package['grafana'],
     }
 
     file { $dashboard_cert_key:
-      ensure => present,
-      source => "${facts['puppet_sslpaths']['privatekeydir']['path']}/${clientcert}.pem",
-      owner  => 'grafana',
-      mode   => "0400",
+      ensure  => present,
+      source  => "${facts['puppet_sslpaths']['privatekeydir']['path']}/${clientcert}.pem",
+      owner   => 'grafana',
+      mode    => '0400',
       require => Package['grafana'],
     }
 
@@ -68,9 +68,9 @@ class pe_metrics_dashboard::install(
   }
   else {
     $cfg = { server    => {
-               http_port => $grafana_http_port,
-             },
-	   }
+              http_port => $grafana_http_port,
+              },
+    }
     $uri = 'http'
   }
 
@@ -95,7 +95,7 @@ class pe_metrics_dashboard::install(
     install_method      => 'repo',
     manage_package_repo => false,
     version             => $grafana_version,
-    cfg                 => $cfg, 
+    cfg                 => $cfg,
     require             => Service[$influx_db_service_name],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,9 +10,9 @@ class pe_metrics_dashboard::params {
   # Default Installation parameters
   $add_dashboard_examples =  false
   $overwrite_dashboards   =  true
-  $use_dashboard_ssl      = false 
-  $dashboard_cert_file    = "/etc/grafana/${clientcert}_cert.pem"      
-  $dashboard_cert_key     = "/etc/grafana/${clientcert}_key.pem"	
+  $use_dashboard_ssl      = false
+  $dashboard_cert_file    = "/etc/grafana/${clientcert}_cert.pem"
+  $dashboard_cert_key     = "/etc/grafana/${clientcert}_key.pem"
   $influxdb_database_name =  ['pe_metrics']
   $grafana_version        =  '4.5.2'
   $grafana_http_port      =  3000

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -3,8 +3,8 @@
 #)
 #
 class pe_metrics_dashboard::telegraf (
-  Boolean $configure_telegraf         =  $pe_metrics_dashboard::params::configure_telegraf,
-  String $influx_db_service_name      =  $pe_metrics_dashboard::params::influx_db_service_name,
+  Boolean $configure_telegraf         =  $pe_metrics_dashboard::configure_telegraf,
+  String $influx_db_service_name      =  $pe_metrics_dashboard::influx_db_service_name,
   Array[String] $additional_metrics   = [],
   ) {
 


### PR DESCRIPTION
Since this module is only installing and configuring the dashboard stack, we should consolidate the install as a part of the main module class. This PR changes the way the module is called, so that everything is done through the main class. It also adds some additional documentation for the parameters and denotes that the pe_metrics_dashboard::install class is private. 