### PR TITLE
(maint) Explicitly set EPP variables

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -123,6 +123,8 @@ class pe_metrics_dashboard::install(
     class { 'pe_metrics_dashboard::telegraf':
       configure_telegraf     => $configure_telegraf,
       influx_db_service_name => $influx_db_service_name,
+      master_list            => $master_list,
+      puppetdb_list          => $puppetdb_list,
     }
   }
 

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -5,6 +5,8 @@
 class pe_metrics_dashboard::telegraf (
   Boolean $configure_telegraf         =  $pe_metrics_dashboard::install::configure_telegraf,
   String $influx_db_service_name      =  $pe_metrics_dashboard::install::influx_db_service_name,
+  Array[String] $master_list          =  $pe_metrics_dashboard::install::master_list,
+  Array[String] $puppetdb_list        =  $pe_metrics_dashboard::install::puppetdb_list,
   Array[String] $additional_metrics   = [],
   ) {
 
@@ -162,7 +164,11 @@ class pe_metrics_dashboard::telegraf (
       owner   => 0,
       group   => 0,
       content => epp('pe_metrics_dashboard/telegraf.conf.epp',
-        {puppetdb_metrics => $puppetdb_metrics}),
+        {
+          puppetdb_metrics => $puppetdb_metrics,
+          master_list      => $master_list,
+          puppetdb_list    => $puppetdb_list,
+        }),
       notify  => Service['telegraf'],
       require => Package['telegraf'],
     }

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -1,51 +1,51 @@
 [global_tags]
 [agent]
-  interval = "10s"
+  interval = '10s'
   round_interval = true
   metric_batch_size = 1000
   metric_buffer_limit = 10000
-  collection_jitter = "0s"
-  flush_interval = "10s"
-  flush_jitter = "0s"
-  precision = ""
+  collection_jitter = '0s'
+  flush_interval = '10s'
+  flush_jitter = '0s'
+  precision = ''
   debug = false
   quiet = false
-  logfile = "/var/log/telegraf/telegraf.log"
-  hostname = ""
+  logfile = '/var/log/telegraf/telegraf.log'
+  hostname = ''
   omit_hostname = false
 [[outputs.influxdb]]
-  urls = ["http://localhost:8086"] # required
-  database = "telegraf" # required
-  retention_policy = ""
-  write_consistency = "any"
-  timeout = "5s"
+  urls = ['http://localhost:8086'] # required
+  database = 'telegraf' # required
+  retention_policy = ''
+  write_consistency = 'any'
+  timeout = '5s'
 
 [[inputs.httpjson]]
-  name = "puppet_stats"
+  name = 'puppet_stats'
   servers = [
     <%# -%>
-    <% unless $pe_metrics_dashboard::install::master_list.empty {-%>
-    <% $pe_metrics_dashboard::install::master_list.each |$master_list| {-%>
-    "https://<%= $master_list %>:8140/status/v1/services?level=debug",
+    <% unless $master_list.empty {-%>
+    <% $master_list.each |$master| {-%>
+    "https://<%= $master %>:8140/status/v1/services?level=debug",
     <% } -%>
     <% } -%>
     <%# -%>
   ]
-  method = "GET"
+  method = 'GET'
   insecure_skip_verify = true
 
 [[inputs.httpjson]]
-  name = "puppetdb_command_queue"
+  name = 'puppetdb_command_queue'
   servers = [
     <%# -%>
-    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
-    <% $pe_metrics_dashboard::install::puppetdb_list.each |$puppetdb_list| {-%>
-    "https://<%= $puppetdb_list %>:8081/status/v1/services?level=debug",
+    <% unless $puppetdb_list.empty {-%>
+    <% $puppetdb_list.each |$puppetdb| {-%>
+    "https://<%= $puppetdb %>:8081/status/v1/services?level=debug",
     <% } -%>
     <% } -%>
     <%# -%>
   ]
-  method = "GET"
+  method = 'GET'
   insecure_skip_verify = true
 
 <%# -%>
@@ -55,14 +55,14 @@
   name = "puppetdb_<%= $metric['name'] %>"
   servers = [
     <%# -%>
-    <% unless $pe_metrics_dashboard::install::puppetdb_list.empty {-%>
-    <% $pe_metrics_dashboard::install::puppetdb_list.each |$master_list| {-%>
-    "https://<%= $master_list %>:8081/metrics/v1/mbeans/<%= $metric['url'] %>",
+    <% unless $puppetdb_list.empty {-%>
+    <% $puppetdb_list.each |$puppetdb| {-%>
+    "https://<%= $puppetdb %>:8081/metrics/v1/mbeans/<%= $metric['url'] %>",
     <% } -%>
     <% } -%>
     <%# -%>
   ]
-  method = "GET"
+  method = 'GET'
   insecure_skip_verify = true
 
 <% } -%>


### PR DESCRIPTION
Prior to this PR, the epp template for telegraf looked for variables
from the pe_metrics_dashboard::install class. This commit sends in the
variables to the epp function. This ensures that the variables will be
passed in if we change the parameters later on.