### PR TITLE
(issue 33) Enable Telegraf configuration by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ Whether to configure the telegraf service.
 
 Valid values are `true`, `false`.
 
-Defaults to `false`
+Defaults to `true`
 
 This parameter enables configuring telegraf to query the `master_list` and `puppetdb_list` endpoints for metrics. Metrics will be stored in the `telegraf` database in InfluxDb. Ensure that `influxdb_database_name` contains `telegraf` when using this parameter.
 
-_Note:_ This parameter is only used if `enable_telegraf` is set to true.
+_Note:_ This parameter enables `enable_telegraf` if set to true.
 
 ##### consume_graphite
 
@@ -207,7 +207,7 @@ An array of databases that should be created in InfluxDB.
 
 Valid values are 'pe_metrics','telegraf', 'graphite', and any other string.
 
-Defaults to `['pe_metrics']`
+Defaults to `['telegraf']`
 
 Each database in the array will be created in InfluxDB. 'pe_metrics','telegraf', and 'graphite' are specially named and will be used with their associated metric collection method. Any other database name will be created, but not utilized with components in this module.
 
@@ -243,7 +243,7 @@ Whether to install telegraf.
 
 Valid values are `true`, `false`.
 
-Defaults to `false`
+Defaults to `true`
 
 Installs telegraf. No configuration is done unless the `configure_telegraf` parameter is set to `true`.
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,6 +20,12 @@ class pe_metrics_dashboard::install(
   Array[String] $puppetdb_list            =  $pe_metrics_dashboard::puppetdb_list
 ) {
 
+  # Enable Telegraf if `configure_telegraf` is true.
+  $_enable_telegraf = $configure_telegraf ? {
+    true    => true,
+    default => $enable_telegraf
+  }
+
   include pe_metrics_dashboard::repos
 
   package { 'influxdb':
@@ -112,7 +118,7 @@ class pe_metrics_dashboard::install(
     }
   }
 
-  if $enable_telegraf {
+  if $_enable_telegraf {
     class { 'pe_metrics_dashboard::telegraf':
       configure_telegraf     => $configure_telegraf,
       influx_db_service_name => $influx_db_service_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class pe_metrics_dashboard::params {
   $use_dashboard_ssl      = false
   $dashboard_cert_file    = "/etc/grafana/${clientcert}_cert.pem"
   $dashboard_cert_key     = "/etc/grafana/${clientcert}_key.pem"
-  $influxdb_database_name =  ['pe_metrics']
+  $influxdb_database_name =  ['telegraf']
   $grafana_version        =  '4.5.2'
   $grafana_http_port      =  3000
   $influx_db_password     =  'puppet'
@@ -24,7 +24,7 @@ class pe_metrics_dashboard::params {
   $enable_kapacitor       =  false
   $enable_chronograf      =  false
   # telegraf config
-  $configure_telegraf     =  false
+  $configure_telegraf     =  true
   $master_list            =  [$::settings::certname]
   $puppetdb_list          =  [$::settings::certname]
 


### PR DESCRIPTION
Prior to this PR, configuring telegraf was disabled by default. This
commit enables and configures telegraf by default. It also enables
telegraf if `configure_telegraf` is set to true.

Resolves #33 