### PR TITLE
(issue 29) Revert params format to fix spec tests

### DIFF
--- a/manifests/dashboards/graphite.pp
+++ b/manifests/dashboards/graphite.pp
@@ -1,7 +1,7 @@
 class pe_metrics_dashboard::dashboards::graphite(
-  Integer $grafana_port       =  $pe_metrics_dashboard::grafana_http_port,
-  String $grafana_password    =  $pe_metrics_dashboard::grafana_password,
-  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::use_dashboard_ssl,
+  Integer $grafana_port       =  $pe_metrics_dashboard::install::grafana_http_port,
+  String $grafana_password    =  $pe_metrics_dashboard::install::grafana_password,
+  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::install::use_dashboard_ssl,
 ) {
 
   if $use_dashboard_ssl {

--- a/manifests/dashboards/pe_metrics.pp
+++ b/manifests/dashboards/pe_metrics.pp
@@ -1,7 +1,7 @@
 class pe_metrics_dashboard::dashboards::pe_metrics(
-  Integer $grafana_port       =  $pe_metrics_dashboard::grafana_http_port,
-  String $grafana_password    =  $pe_metrics_dashboard::grafana_password,
-  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::use_dashboard_ssl,
+  Integer $grafana_port       =  $pe_metrics_dashboard::install::grafana_http_port,
+  String $grafana_password    =  $pe_metrics_dashboard::install::grafana_password,
+  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::install::use_dashboard_ssl,
 ) {
 
   if $use_dashboard_ssl {

--- a/manifests/dashboards/telegraf.pp
+++ b/manifests/dashboards/telegraf.pp
@@ -1,7 +1,7 @@
 class pe_metrics_dashboard::dashboards::telegraf(
-  Integer $grafana_port     =  $pe_metrics_dashboard::grafana_http_port,
-  String $grafana_password  =  $pe_metrics_dashboard::grafana_password,
-  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::use_dashboard_ssl,
+  Integer $grafana_port       =  $pe_metrics_dashboard::install::grafana_http_port,
+  String $grafana_password    =  $pe_metrics_dashboard::install::grafana_password,
+  Boolean $use_dashboard_ssl  =  $pe_metrics_dashboard::install::use_dashboard_ssl,
 ) {
 
   if $use_dashboard_ssl {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,24 +1,24 @@
 class pe_metrics_dashboard::install(
-  Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::add_dashboard_examples,
-  Boolean $use_dashboard_ssl              =  $pe_metrics_dashboard::use_dashboard_ssl,
-  String $dashboard_cert_file             =  $pe_metrics_dashboard::dashboard_cert_file,
-  String $dashboard_cert_key              =  $pe_metrics_dashboard::dashboard_cert_key,
-  Boolean $overwrite_dashboards           =  $pe_metrics_dashboard::overwrite_dashboards,
-  String $overwrite_dashboards_file       =  $pe_metrics_dashboard::overwrite_dashboards_file,
-  String $influx_db_service_name          =  $pe_metrics_dashboard::influx_db_service_name,
-  Array[String] $influxdb_database_name   =  $pe_metrics_dashboard::influxdb_database_name,
-  String $grafana_version                 =  $pe_metrics_dashboard::grafana_version,
-  Integer $grafana_http_port              =  $pe_metrics_dashboard::grafana_http_port,
-  String $influx_db_password              =  $pe_metrics_dashboard::influx_db_password,
-  String $grafana_password                =  $pe_metrics_dashboard::grafana_password,
-  Boolean $enable_kapacitor               =  $pe_metrics_dashboard::enable_kapacitor,
-  Boolean $enable_chronograf              =  $pe_metrics_dashboard::enable_chronograf,
-  Boolean $enable_telegraf                =  $pe_metrics_dashboard::enable_telegraf,
-  Boolean $configure_telegraf             =  $pe_metrics_dashboard::configure_telegraf,
-  Boolean $consume_graphite               =  $pe_metrics_dashboard::consume_graphite,
-  Array[String] $master_list              =  $pe_metrics_dashboard::master_list,
-  Array[String] $puppetdb_list            =  $pe_metrics_dashboard::puppetdb_list
-) {
+  Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::params::add_dashboard_examples,
+  Boolean $use_dashboard_ssl              =  $pe_metrics_dashboard::params::use_dashboard_ssl,
+  String $dashboard_cert_file             =  $pe_metrics_dashboard::params::dashboard_cert_file,
+  String $dashboard_cert_key              =  $pe_metrics_dashboard::params::dashboard_cert_key,
+  Boolean $overwrite_dashboards           =  $pe_metrics_dashboard::params::overwrite_dashboards,
+  String $overwrite_dashboards_file       =  $pe_metrics_dashboard::params::overwrite_dashboards_file,
+  String $influx_db_service_name          =  $pe_metrics_dashboard::params::influx_db_service_name,
+  Array[String] $influxdb_database_name   =  $pe_metrics_dashboard::params::influxdb_database_name,
+  String $grafana_version                 =  $pe_metrics_dashboard::params::grafana_version,
+  Integer $grafana_http_port              =  $pe_metrics_dashboard::params::grafana_http_port,
+  String $influx_db_password              =  $pe_metrics_dashboard::params::influx_db_password,
+  String $grafana_password                =  $pe_metrics_dashboard::params::grafana_password,
+  Boolean $enable_kapacitor               =  $pe_metrics_dashboard::params::enable_kapacitor,
+  Boolean $enable_chronograf              =  $pe_metrics_dashboard::params::enable_chronograf,
+  Boolean $enable_telegraf                =  $pe_metrics_dashboard::params::enable_telegraf,
+  Boolean $configure_telegraf             =  $pe_metrics_dashboard::params::configure_telegraf,
+  Boolean $consume_graphite               =  $pe_metrics_dashboard::params::consume_graphite,
+  Array[String] $master_list              =  $pe_metrics_dashboard::params::master_list,
+  Array[String] $puppetdb_list            =  $pe_metrics_dashboard::params::puppetdb_list
+) inherits pe_metrics_dashboard::params {
 
   include pe_metrics_dashboard::repos
 

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -3,8 +3,8 @@
 #)
 #
 class pe_metrics_dashboard::telegraf (
-  Boolean $configure_telegraf         =  $pe_metrics_dashboard::configure_telegraf,
-  String $influx_db_service_name      =  $pe_metrics_dashboard::influx_db_service_name,
+  Boolean $configure_telegraf         =  $pe_metrics_dashboard::install::configure_telegraf,
+  String $influx_db_service_name      =  $pe_metrics_dashboard::install::influx_db_service_name,
   Array[String] $additional_metrics   = [],
   ) {
 

--- a/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
@@ -7,6 +7,6 @@ HOSTS:
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
       # ensure that upstart is booting correctly in the container
-      - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8'
+      - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget apt-transport-https && locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200

--- a/spec/acceptance/nodesets/docker/ubuntu-16.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-16.04.yml
@@ -6,6 +6,6 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'apt-get update && apt-get install -y locales net-tools wget && locale-gen en_US.UTF-8'
+      - 'apt-get update && apt-get install -y locales net-tools wget apt-transport-https && locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 describe 'pe_metrics_dashboard' do
   context 'with default values for all parameters' do
+      let(:facts) do
+      {
+          :osfamily => 'RedHat',
+          :os => {
+            :family => 'RedHat',
+          },
+          :operatingsystem => 'RedHat',
+          :pe_server_version => '2017.2',
+      }
+    end
     it { should contain_class('pe_metrics_dashboard') }
   end
 end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -23,6 +23,7 @@ describe 'pe_metrics_dashboard::install' do
         :grafana_http_port => 3000,
         :influx_db_password => "puppet",
         :grafana_password => "admin",
+        :use_dashboard_ssl => false,
 
       }
     end
@@ -171,6 +172,7 @@ describe 'pe_metrics_dashboard::install' do
         :add_dashboard_examples => true,
         :grafana_password => "admin",
         :grafana_http_port => 3000,
+        :use_dashboard_ssl => false,
       }
     end
 


### PR DESCRIPTION
Prior to this PR, the spec tests were all failing because they could
not find variables from the pe_metrics_dashboard class. This commit
changes the install class to inherit from the params class and the
subclasses to pull default parameters from the install class. This
commit also fixes the broken spec tests that resulted from recent
changes in the module.

This commit resolves #29 and #22