### PR TITLE
(SUP-189) Add documentation to the init

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,47 +1,116 @@
 # Class: pe_metrics_dashboard
 # ===========================
 #
-# Full description of class pe_metrics_dashboard here.
+# The pe_metrics_dashboard module installs and configures an InfluxDB stack
+# monitor the Puppet Enterprise infrastructure components.
 #
 # Parameters
 # ----------
 #
-# Document parameters here.
+# * `add_dashboard_examples`
+# Whether to add the Grafana dashboard example dashboards for the configured InfluxDB databases.
+# Valid values are `true`, `false`. Defaults to `false`.
+# *Note:* These dashboards are managed and any changes will be overwritten unless the `overwrite_dashboards` is set to `false`.
 #
-# * `sample parameter`
-# Explanation of what this parameter affects and what it defaults to.
-# e.g. "Specify one or more upstream ntp servers as an array."
+# * `dashboard_cert_file`
+# The location of the Grafana certficiate.
+# Defaults to `"/etc/grafana/${clientcert}_cert.pem"`
+# Only used when configuring `use_dashboard_ssl` is true.
 #
-# Variables
-# ----------
+# * `dashboard_cert_key`
+# The location of the Grafana private key.
+# Defaults to `"/etc/grafana/${clientcert}_key.pem"`
+# Only used when configuring `use_dashboard_ssl` is true.
 #
-# Here you should define a list of variables that this module would require.
+# * `configure_telegraf`
+# Whether to configure the telegraf service.
+# Valid values are `true`, `false`. Defaults to `true`
+# This parameter enables configuring telegraf to query the `master_list` and `puppetdb_list` endpoints for metrics. Metrics will be stored in the `telegraf` database in InfluxDb. Ensure that `influxdb_database_name` contains `telegraf` when using this parameter.
+# _Note:_ This parameter is only used if `enable_telegraf` is set to true.
 #
-# * `sample variable`
-#  Explanation of how this variable affects the function of this class and if
-#  it has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#  External Node Classifier as a comma separated list of hostnames." (Note,
-#  global variables should be avoided in favor of class parameters as
-#  of Puppet 2.6.)
+# * `consume_graphite`
+# Whether to enable the InfluxDB Graphite plugin.
+# Valid values are `true`, `false`. Defaults to `false`
+# This parameter enables the Graphite plugin for InfluxDB to allow for injesting Graphite metrics. Ensure `influxdb_database_name` contains `graphite` when using this parameter.
+# *Note:* If using Graphite metrics from the Puppet Master, this needs to be set to `true`.
 #
+# * `grafana_http_port`
+# The port to run Grafana on.
+# Valid values are Integers from `1024` to `65536`. Defaults to `3000`
+# The grafana port for the web interface. This should be a nonprivileged port (above 1024).
+#
+# * `grafana_password`
+# The password for the Grafana admin user.
+# Defaults to `'admin'`
+#
+# * `grafana_version`
+# The grafana version to install.
+# Valid values are String versions of Grafana. Defaults to `'4.5.2'`
+#
+# * `influxdb_database_name`
+# An array of databases that should be created in InfluxDB.
+# Valid values are 'pe_metrics','telegraf', 'graphite', and any other string. Defaults to `['pe_metrics']`
+# Each database in the array will be created in InfluxDB. 'pe_metrics','telegraf', and 'graphite' are specially named and will be used with their associated metric collection method. Any other database name will be created, but not utilized with components in this module.
+#
+# * `influx_db_password`
+# The password for the InfluxDB admin user.
+# Defaults to `'puppet'`
+#
+# * `enable_kapacitor`
+# Whether to install kapacitor.
+# Valid values are `true`, `false`. Defaults to `false`
+# Install kapacitor. No configuration of kapacitor is included at this time.
+#
+# * `enable_chronograf`
+# Whether to install chronograf.
+# Valid values are `true`, `false`. Defaults to `false`
+# Installs chronograf. No configuration of chronograf is included at this time.
+#
+# * `enable_telegraf`
+# Whether to install telegraf.
+# Valid values are `true`, `false`. Defaults to `false`
+# Installs telegraf. No configuration is done unless the `configure_telegraf` parameter is set to `true`.
+#
+# * `master_list`
+# An array of Puppet Master servers to collect metrics from. Defaults to `["$::settings::certname"]`
+# A list of Puppet master servers that will be configured for telegraf to query.
+#
+# * `overwrite_dashboards`
+# Whether to overwrite the example Grafana dashboards.
+# Valid values are `true`, `false`. Defaults to `false`
+# This paramater disables overwriting the example Grafana dashboards. It takes effect after the second Puppet run and popultes the `overwrite_dashboards_disabled` fact. This only takes effect when `add_dashboard_examples` is set to true.
+#
+# * `puppetdb_list`
+# An array of PuppetDB servers to collect metrics from. Defaults to `["$::settings::certname"]`
+# A list of PuppetDB servers that will be configured for telegraf to query.
+#
+# * `use_dashboard_ssl`
+# Whether to enable SSL on Grafana.
+#
+# Valid values are `true`, `false`. Defaults to `false`
+
 # Examples
 # --------
 #
 # @example
 #    class { 'pe_metrics_dashboard':
-#      servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
+#      configure_telegraf  => true,
+#      enable_telegraf     => true,
+#      master_list         => ['master1.com','master2.com'],
+#      puppetdb_list       => ['puppetdb1','puppetdb2'],
 #    }
+#
+#
+# Summary
+# -------
+# @summary Installs and configures Grafana with InfluxDB for monitoring PE.
 #
 # Authors
 # -------
 #
-# Author Name <author@domain.com>
-#
-# Copyright
-# ---------
-#
-# Copyright 2017 Your name here, unless otherwise noted.
-#
+# Erik Hansen <erik.hansen@puppet.com>
+# Jarret Lavallee <jarret@puppet.com>
+
 class pe_metrics_dashboard (
   Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::params::add_dashboard_examples,
   Boolean $use_dashboard_ssl              =  $pe_metrics_dashboard::params::use_dashboard_ssl,
@@ -62,9 +131,9 @@ class pe_metrics_dashboard (
   Boolean $consume_graphite               =  $pe_metrics_dashboard::params::consume_graphite,
   Array[String] $master_list              =  $pe_metrics_dashboard::params::master_list,
   Array[String] $puppetdb_list            =  $pe_metrics_dashboard::params::puppetdb_list
-) inherits pe_metrics_dashboard::params {
+  ) inherits pe_metrics_dashboard::params {
 
-  class { 'pe_metrics_dashboard::install':
+    class { 'pe_metrics_dashboard::install':
     add_dashboard_examples    =>  $add_dashboard_examples,
     use_dashboard_ssl         =>  $use_dashboard_ssl,
     dashboard_cert_file       =>  $dashboard_cert_file,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,3 +1,4 @@
+# @summary Installs and configures Grafana and INfluxDB components.
 class pe_metrics_dashboard::install(
   Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::add_dashboard_examples,
   Boolean $use_dashboard_ssl              =  $pe_metrics_dashboard::use_dashboard_ssl,


### PR DESCRIPTION
Prior to this PR, there was no documentation for the parameters
inside of the init.pp. This commit adds some basic documentation into
the init.pp