### PR TITLE
(issue #46) Unmanage repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ Defaults to `true`
 
 Installs telegraf. No configuration is done unless the `configure_telegraf` parameter is set to `true`.
 
+##### manage_repos
+
+Whether or not to setup yum / apt repositories for the dependent packages
+
+Valid values are `true`, `false`. 
+
+Defaults to `true`
+
 ##### master_list
 
 An array of Puppet Master servers to collect metrics from.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,10 @@
 # Valid values are `true`, `false`. Defaults to `false`.
 # *Note:* These dashboards are managed and any changes will be overwritten unless the `overwrite_dashboards` is set to `false`.
 #
+# * `manage_repos`
+# Whether or not to setup yum / apt repositories for the dependent packages
+# Valid values are `true`, `false`. Defaults to `true`
+#
 # * `dashboard_cert_file`
 # The location of the Grafana certficiate.
 # Defaults to `"/etc/grafana/${clientcert}_cert.pem"`
@@ -113,6 +117,7 @@
 
 class pe_metrics_dashboard (
   Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::params::add_dashboard_examples,
+  Boolean $manage_repos                   =  $pe_metrics_dashboard::params::manage_repos,
   Boolean $use_dashboard_ssl              =  $pe_metrics_dashboard::params::use_dashboard_ssl,
   String $dashboard_cert_file             =  $pe_metrics_dashboard::params::dashboard_cert_file,
   String $dashboard_cert_key              =  $pe_metrics_dashboard::params::dashboard_cert_key,
@@ -135,6 +140,7 @@ class pe_metrics_dashboard (
 
     class { 'pe_metrics_dashboard::install':
     add_dashboard_examples    =>  $add_dashboard_examples,
+    manage_repos              =>  $manage_repos,
     use_dashboard_ssl         =>  $use_dashboard_ssl,
     dashboard_cert_file       =>  $dashboard_cert_file,
     dashboard_cert_key        =>  $dashboard_cert_key,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,7 @@
 # @summary Installs and configures Grafana and INfluxDB components.
 class pe_metrics_dashboard::install(
   Boolean $add_dashboard_examples         =  $pe_metrics_dashboard::params::add_dashboard_examples,
+  Boolean $manage_repos                   =  $pe_metrics_dashboard::params::manage_repos,
   Boolean $use_dashboard_ssl              =  $pe_metrics_dashboard::params::use_dashboard_ssl,
   String $dashboard_cert_file             =  $pe_metrics_dashboard::params::dashboard_cert_file,
   String $dashboard_cert_key              =  $pe_metrics_dashboard::params::dashboard_cert_key,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,8 +9,9 @@ class pe_metrics_dashboard::params {
 
   # Default Installation parameters
   $add_dashboard_examples =  false
+  $manage_repos           =  true
   $overwrite_dashboards   =  true
-  $use_dashboard_ssl      = false
+  $use_dashboard_ssl      =  false
   $dashboard_cert_file    = "/etc/grafana/${clientcert}_cert.pem"
   $dashboard_cert_key     = "/etc/grafana/${clientcert}_key.pem"
   $influxdb_database_name =  ['telegraf']

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -3,27 +3,29 @@ class pe_metrics_dashboard::repos{
   case $::osfamily {
 
     'RedHat': {
+       
+      if ( $::pe_metrics_dashboard::manage_repos ){
+        yumrepo {'influxdb':
+          ensure   => present,
+          enabled  => 1,
+          gpgcheck => 1,
+          baseurl  => 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable',
+          gpgkey   => 'https://repos.influxdata.com/influxdb.key',
+          before   => Package['influxdb'],
+        }
 
-      yumrepo {'influxdb':
-        ensure   => present,
-        enabled  => 1,
-        gpgcheck => 1,
-        baseurl  => 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable',
-        gpgkey   => 'https://repos.influxdata.com/influxdb.key',
-        before   => Package['influxdb'],
-      }
-
-      yumrepo { 'grafana-repo':
-        ensure        => 'present',
-        baseurl       => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
-        descr         => 'grafana-repository',
-        enabled       => '1',
-        repo_gpgcheck => '1',
-        gpgcheck      => '1',
-        gpgkey        => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
-        sslverify     => '1',
-        sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
-        before        => Class['grafana'],
+        yumrepo { 'grafana-repo':
+          ensure        => 'present',
+          baseurl       => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
+          descr         => 'grafana-repository',
+          enabled       => '1',
+          repo_gpgcheck => '1',
+          gpgcheck      => '1',
+          gpgkey        => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
+          sslverify     => '1',
+          sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
+          before        => Class['grafana'],
+        }
       }
     }
 
@@ -32,26 +34,28 @@ class pe_metrics_dashboard::repos{
       $_operatingsystem = downcase($::facts['os']['name'])
       $_oscodename = downcase($::facts['os']['distro']['codename'])
 
-      apt::source { 'influxdb':
-        location => "https://repos.influxdata.com/${_operatingsystem}",
-        release  => $_oscodename,
-        repos    => 'stable',
-        key      =>  {
-          'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',
-          'source' => 'https://repos.influxdata.com/influxdb.key',
-        },
-        before   => Package['influxdb'],
-      }
+      if ( $::pe_metrics_dashboard::manage_repos ){
+        apt::source { 'influxdb':
+          location => "https://repos.influxdata.com/${_operatingsystem}",
+          release  => $_oscodename,
+          repos    => 'stable',
+          key      =>  {
+            'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',
+            'source' => 'https://repos.influxdata.com/influxdb.key',
+          },
+          before   => Package['influxdb'],
+        }
 
-      apt::source { 'grafana':
-        location => 'https://packagecloud.io/grafana/stable/debian/',
-        release  => 'jessie',
-        repos    => 'main',
-        key      =>  {
-          'id'     => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
-          'source' => 'https://packagecloud.io/gpg.key',
-        },
-        before   => Package['grafana'],
+        apt::source { 'grafana':
+          location => 'https://packagecloud.io/grafana/stable/debian/',
+          release  => 'jessie',
+          repos    => 'main',
+          key      =>  {
+            'id'     => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
+            'source' => 'https://packagecloud.io/gpg.key',
+          },
+          before   => Package['grafana'],
+        }
       }
     }
 


### PR DESCRIPTION
This commit adds the ability to *not* manage apt / yum repos.

This fills a requirement for some folks that need to host repos internally and / or that can't reach public repos.