### PR TITLE
(maint) Spec test cleanup for repo management

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,7 +28,9 @@ class pe_metrics_dashboard::install(
     default => $enable_telegraf
   }
 
-  include pe_metrics_dashboard::repos
+  class { pe_metrics_dashboard::repos:
+    manage_repos => $manage_repos,
+  }
 
   package { 'influxdb':
     ensure  => present,

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -1,10 +1,11 @@
-class pe_metrics_dashboard::repos{
+class pe_metrics_dashboard::repos (
+  Boolean $manage_repos = $pe_metrics_dashboard::install::manage_repos,
+) {
 
   case $::osfamily {
 
     'RedHat': {
-       
-      if ( $::pe_metrics_dashboard::manage_repos ){
+      if ( $manage_repos ){
         yumrepo {'influxdb':
           ensure   => present,
           enabled  => 1,
@@ -34,7 +35,7 @@ class pe_metrics_dashboard::repos{
       $_operatingsystem = downcase($::facts['os']['name'])
       $_oscodename = downcase($::facts['os']['distro']['codename'])
 
-      if ( $::pe_metrics_dashboard::manage_repos ){
+      if ( $manage_repos ){
         apt::source { 'influxdb':
           location => "https://repos.influxdata.com/${_operatingsystem}",
           release  => $_oscodename,

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper_acceptance'
+
+describe 'pe_metrics_dashboard class' do
+  context 'default parameters' do
+    it 'should install grafana and influxdb' do
+      pp = <<-EOS
+    		class {'pe_metrics_dashboard':
+          grafana_version => '4.6.1',
+          grafana_http_port => 3000,
+        }
+        EOS
+
+      # Run it twice and test for idempotency
+      expect(apply_manifest(pp).exit_code).to_not eq(1)
+      expect(apply_manifest(pp).exit_code).to eq(0)
+    end
+    # Grafana should be running
+ #   describe service('grafana-server') do
+ #     it { should be_running }
+ #   end
+    describe port('3000') do
+      it { should be_listening }
+    end
+
+    # Influxdb should be listening on port 8086 by default
+    describe port('8086') do
+      it { should be_listening }
+    end
+  end
+end

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -8,6 +8,11 @@ describe 'pe_metrics_dashboard::repos' do
           :operatingsystem => 'RedHat',
       }
     end
+    let(:params) do
+      {
+        :manage_repos => true,
+      }
+    end
 
     it do
       is_expected.to contain_yumrepo("influxdb")
@@ -38,6 +43,28 @@ describe 'pe_metrics_dashboard::repos' do
     end
   end
 
+  context "on RedHat with manage_repo false" do
+    let(:facts) do
+      {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'RedHat',
+      }
+    end
+    let(:params) do
+      {
+        :manage_repos => false,
+      }
+    end
+
+    it do
+      is_expected.not_to contain_yumrepo("influxdb")
+    end
+
+    it do
+      is_expected.not_to contain_yumrepo("grafana-repo")
+    end
+  end
+
   context "on Ubuntu" do
     let(:facts) do
       {
@@ -61,6 +88,11 @@ describe 'pe_metrics_dashboard::repos' do
         :pe_server_version => '2017.2',
       }
     end
+    let(:params) do
+      {
+        :manage_repos => true,
+      }
+    end
 
     it do
       is_expected.to contain_apt__source("influxdb")
@@ -80,6 +112,44 @@ describe 'pe_metrics_dashboard::repos' do
             "repos" => "main",
             "before" => "Package[grafana]",
             })
+    end
+  end
+
+  context "on Ubuntu with manage_repo false" do
+    let(:facts) do
+      {
+        :os => {
+            :family => 'Debian',
+            :name  => 'Ubuntu',
+            :release => {
+                :major => '14',
+                :full => '14.04.5'
+            },
+            :distro => {
+              :codename => "trusty",
+            },
+        },
+        :osfamily => 'Debian',
+        :lsbdistcodename => 'trusty',
+        :lsbdistid => 'ubuntu',
+        :lsbdistrelease => '14.04',
+        :puppetversion => Puppet.version,
+        :operatingsystem => 'Ubuntu',
+        :pe_server_version => '2017.2',
+      }
+    end
+    let(:params) do
+      {
+        :manage_repos => false,
+      }
+    end
+
+    it do
+      is_expected.not_to contain_apt__source("influxdb")
+    end
+
+    it do
+      is_expected.not_to contain_apt__source("grafana")
     end
   end
 


### PR DESCRIPTION
This PR fixes the spec tests around the manage_repo parameter. New spec tests are added to test the manage_repo parameter and to test the init class for acceptance. 