### PR TITLE
Add compile time metric to the avg borrow time graph

### DIFF
--- a/files/PuppetDB_Performance.json
+++ b/files/PuppetDB_Performance.json
@@ -226,7 +226,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "global_processed.FiveMinuteRate",
+              "measurement": "global_processing-time.95thPercentile",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -235,7 +235,7 @@
                 [
                   {
                     "params": [
-                      "FiveMinuteRate"
+                      "95thPercentile"
                     ],
                     "type": "field"
                   },
@@ -855,5 +855,5 @@
   },
   "timezone": "",
   "title": "Archive PuppetDB Performance",
-  "version": 11
+  "version": 12
 }

--- a/files/PuppetDB_Workload.json
+++ b/files/PuppetDB_Workload.json
@@ -594,6 +594,12 @@
                 },
                 {
                   "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
                     "null"
                   ],
                   "type": "fill"

--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -95,7 +95,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "ave. free jrubies",
+              "alias": "$tag_server-avg-free-jrubies",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -148,7 +148,7 @@
               ]
             },
             {
-              "alias": "ave. requested jrubies",
+              "alias": "$tag_server-avg-requested-jrubies",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -198,7 +198,7 @@
               ]
             },
             {
-              "alias": "average-wait-time",
+              "alias": "$tag_server-avg-wait-time",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -206,6 +206,12 @@
                     "10s"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -242,7 +248,7 @@
               ]
             },
             {
-              "alias": "average-borrow-time",
+              "alias": "$tag_server-avg-borrow-time",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -250,6 +256,12 @@
                     "10s"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -384,7 +396,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "heap used",
+              "alias": "$tag_server-heap-used",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -434,7 +446,7 @@
               ]
             },
             {
-              "alias": "heap commited",
+              "alias": "$tag_server-heap-committed",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -614,7 +626,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "ave requested jrubies",
+              "alias": "$tag_server-avg-req-jrubies",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -732,12 +744,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "Avg borrow time",
+              "alias": "$tag_server-avg-borrow-time",
               "dsType": "influxdb",
               "groupBy": [
                 {
                   "params": [
-                    "10s"
+                    "1m"
                   ],
                   "type": "time"
                 },
@@ -782,7 +794,7 @@
               ]
             },
             {
-              "alias": "Mean catalog compile time",
+              "alias": "$tag_server-mean-catalog-compile-time",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -790,6 +802,12 @@
                     "1m"
                   ],
                   "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
                 },
                 {
                   "params": [
@@ -906,7 +924,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "ave free jrubies",
+              "alias": "$tag_server-avg-free-jrubies",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1024,7 +1042,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "ave wait time",
+              "alias": "$tag_server-avg-wait-time",
               "dsType": "influxdb",
               "groupBy": [
                 {

--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -732,7 +732,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "ave borrow time",
+              "alias": "Avg borrow time",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -780,12 +780,56 @@
                   "value": "/^$server$/"
                 }
               ]
+            },
+            {
+              "alias": "Mean catalog compile time",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1m"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "puppetserver.pe-puppet-profiler.catalog-metrics",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "server",
+                  "operator": "=~",
+                  "value": "/^$server$/"
+                }
+              ]
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Average Borrow Time",
+          "title": "Average Borrow Time / Compile Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1135,5 +1179,5 @@
   },
   "timezone": "",
   "title": "Archive Puppetserver Performance",
-  "version": 10
+  "version": 11
 }


### PR DESCRIPTION
Compile time should always be < borrow time so it's interesting
to see these graphed next to one another.

If there's a large gap between them we can investigate what happens
during a borrow other than compilation to see if it can be reduced.

Looks like: 

![image](https://user-images.githubusercontent.com/513998/35743453-8cb9f0f8-07f2-11e8-8224-bd24c70325b2.png)
