### PR TITLE
Use pe jruby metrics on file sync archive dashboard

### DIFF
--- a/files/Archive_File_Sync.json
+++ b/files/Archive_File_Sync.json
@@ -2,12 +2,11 @@
   "annotations": {
     "list": []
   },
-  "editMode": false,
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": false,
-  "id": 10,
+  "id": 9,
   "links": [
     {
       "icon": "external link",
@@ -88,7 +87,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.jruby-metrics.average-lock-held-time",
+              "measurement": "puppetserver.pe-jruby-metrics.average-lock-held-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -138,7 +137,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.jruby-metrics.average-lock-wait-time",
+              "measurement": "puppetserver.pe-jruby-metrics.average-lock-wait-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "B",


### PR DESCRIPTION
In newer versions of PE there are jruby metrics under a PE
namespace and a non PE namespace.  However, in older versions
of PE they are only available under the PE namespace.

We use the PE namespaced metrics to be compatible with the most
versions of PE.